### PR TITLE
Add more supported models.

### DIFF
--- a/installer
+++ b/installer
@@ -983,7 +983,7 @@ write_manager_script () {
 [ -z "$(nvram get odmpid)" ] && ROUTER_MODEL="$(nvram get productid)" || ROUTER_MODEL="$(nvram get odmpid)"
 RURL="https://raw.githubusercontent.com/jumpsmm7/Asuswrt-Merlin-AdGuardHome-Installer/${BRANCH}"
 ROUTER_OS="$(/bin/uname)"
-ROUTER_ARCH="$(/bin/uname -m)"
+! PTXT "$ROUTER_MODEL" | grep -vE "RT-AC(86|2900)" | grep -q "AC" && ROUTER_ARCH="$(/bin/uname -m)" || ROUTER_ARCH="armv7" # Exception for version ARMv5
 NAT_ENV="$(nvram get wan_ipaddr | grep -oE '\b^(((10|127)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3})|(((172\.(1[6-9]|2[0-9]|3[0-1]))|(192\.168))(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){2}))$\b')"
 
 [ -z "$ROUTER_MODEL" ] && PTXT "$ERROR This is an unsupported router, sorry." && sleep 3 && exit 1
@@ -1006,10 +1006,6 @@ if [ -z "$2" ]; then
 fi
 
 case "$ROUTER_MODEL" in
-  RT-AX56U|RT-AX58U|RT-AX3000|RT-AX68U|RT-AX86U|RT-AX86S|DSL-AX82U|DSL-AX5400|RT-AX82U|TUF-AX5400|TUF-AX3000|RT-AX95Q)
-    [ -z "$2" ] && PTXT "$INFO Detected $ROUTER_MODEL router."
-    [ "$(/bin/uname -m)" != "armv7l" ] && ROUTER_ARCH="$(/bin/uname -m)" || ROUTER_ARCH="armv7"
-    ;;
   *)
     [ -z "$2" ] && PTXT "$INFO Detected $ROUTER_MODEL router."
     ;;
@@ -1033,12 +1029,12 @@ case "$ROUTER_ARCH" in
     [ -z "$2" ] && PTXT "$INFO Detected ARMv8 architecture."
     ;;
   "armv7l")
-    ROUTER_ARCH="armv5"
+    ROUTER_ARCH="armv7"
     ADGUARD_ARCH="${ROUTER_OS}_${ROUTER_ARCH}"
     [ -z "$2" ] && PTXT "$INFO Detected ARMv7 architecture."
     ;;
   "armv7")
-    ROUTER_ARCH="armv7"
+    ROUTER_ARCH="armv5"
     ADGUARD_ARCH="${ROUTER_OS}_${ROUTER_ARCH}"
     [ -z "$2" ] && PTXT "$INFO Detected ARMv7 architecture."
     ;;

--- a/installer
+++ b/installer
@@ -1006,7 +1006,7 @@ if [ -z "$2" ]; then
 fi
 
 case "$ROUTER_MODEL" in
-  RT-AX56U|RT-AX58U|RT-AX3000|RT-AX68U|RT-AX86U|RT-AX86S)
+  RT-AX56U|RT-AX58U|RT-AX3000|RT-AX68U|RT-AX86U|RT-AX86S|DSL-AX82U|DSL-AX5400|RT-AX82U|TUF-AX5400|TUF-AX3000|RT-AX95Q)
     [ -z "$2" ] && PTXT "$INFO Detected $ROUTER_MODEL router."
     [ "$(/bin/uname -m)" != "armv7l" ] && ROUTER_ARCH="$(/bin/uname -m)" || ROUTER_ARCH="armv7"
     ;;

--- a/installer.md5sum
+++ b/installer.md5sum
@@ -1,1 +1,1 @@
-8d27e7f4e5f8adc1cf9faeba8ee583fc
+1ce9432078dac14f62ffbbe5cd304439


### PR DESCRIPTION
Gnuton fork models are being added with limited supported.  Issues related to fork installations can only be troubleshooted if they did not derive from firmware related difference from RMerlin firmware.