### PR TITLE
Remove -k/--insecure from curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ https://github.com/jumpsmm7/Asuswrt-Merlin-AdGuardHome-Installer/commits/master
 # Install/Update/Reconfig/Uninstall:
 Run this command from ssh shell and following the prompt for AdGuardHome:
 ```
-curl -L -s -k -O https://raw.githubusercontent.com/jumpsmm7/Asuswrt-Merlin-AdGuardHome-Installer/master/installer && sh installer
+curl -L -s -O https://raw.githubusercontent.com/jumpsmm7/Asuswrt-Merlin-AdGuardHome-Installer/master/installer && sh installer
 ```
 # Terminal commands to for AdGuardHome are:
 ```


### PR DESCRIPTION
`-k` opens the door for bad actors to tamper with the install script.

https://curl.se/docs/manpage.html#-k