### PR TITLE
tools: add helper validation and hardening roadmap

### DIFF
--- a/docs/installer-hardening-roadmap.md
+++ b/docs/installer-hardening-roadmap.md
@@ -1,0 +1,51 @@
+# Installer Hardening Roadmap
+
+This roadmap describes a low-risk path for making the installer safer and easier to maintain without destabilizing existing installs.
+
+## Phase 1: Validation and Documentation
+
+- Keep `sh -n installer` as the required CI check.
+- Keep ShellCheck advisory-only until the legacy installer has been cleaned up.
+- Document helper scripts and expected merge order.
+- Avoid changing the active installer until helpers have been reviewed.
+
+## Phase 2: Safe One-Line Behavior Fixes
+
+Prioritize fixes that reduce risk without changing user-facing behavior:
+
+- Replace partial package matching with exact package matching.
+- Quote package names and file paths.
+- Avoid overwriting `.err` and backup files when timestamped names are safer.
+- Prefer `python3` when installing Python 3 dependencies.
+- Avoid password interpolation into inline Python source.
+
+## Phase 3: Helper Integration
+
+Fold helper logic into the installer in small pull requests:
+
+1. Add exact package detection helper.
+2. Add centralized download helper.
+3. Add timestamped backup helper.
+4. Add service start/stop/restart helper functions.
+5. Replace repeated service-control blocks one call site at a time.
+
+## Phase 4: Diagnostics
+
+Add a user-facing debug bundle option after the design is reviewed and tested.
+
+The debug bundle should:
+
+- Exclude `.config` by default.
+- Save to `/tmp` by default.
+- Print the output archive path.
+- Warn users to review the archive before sharing it.
+
+## Phase 5: Release Discipline
+
+Before each release:
+
+- Confirm `sh -n installer` passes.
+- Confirm helper scripts pass `sh -n`.
+- Test install/update/reconfigure/uninstall paths.
+- Test at least one clean install and one update install.
+- Confirm README install command points to the intended branch.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,43 @@
+# Helper Scripts
+
+This directory contains standalone helper scripts and staged helper functions for improving the Asuswrt-Merlin-AdGuardHome-Installer codebase.
+
+These files are not automatically sourced by the main `installer` unless that behavior is explicitly added in a future pull request.
+
+## Current Helpers
+
+### `installer-safety-helpers.sh`
+
+Staged functions for safer installer behavior:
+
+- Exact Entware package detection.
+- Install-only-when-missing package helper.
+- Safer temporary file creation.
+- Password hashing through `python3` standard input.
+- Centralized download helper with `curl` and `wget` fallback.
+- Timestamped file backup helper.
+
+### `agh-service-helpers.sh`
+
+Staged functions for future service-control cleanup:
+
+- AdGuard Home process detection.
+- Expected process-count waits with timeouts.
+- Start, stop, restart, and check wrappers.
+
+## Integration Rules
+
+Before moving any helper into the main installer:
+
+1. Keep the change in a focused branch.
+2. Preserve BusyBox/ash compatibility.
+3. Run `sh -n` against the changed files.
+4. Test on a router or close Asuswrt-Merlin/Entware environment.
+5. Avoid mixing behavior changes and refactors in the same pull request.
+
+## Suggested Merge Order
+
+1. Documentation and CI changes.
+2. Helper files under `tools/`.
+3. Small installer changes that use one helper at a time.
+4. Larger service-flow cleanup only after the smaller helper integrations are proven stable.

--- a/tools/validate.sh
+++ b/tools/validate.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Local validation runner for repository shell files.
+# BusyBox/ash-compatible.
+
+set -u
+
+FAILED=0
+
+check_syntax() {
+	_file="$1"
+	printf '%s\n' "Checking syntax: ${_file}"
+	if ! sh -n "${_file}"; then
+		FAILED=1
+	fi
+}
+
+check_syntax installer
+
+if [ -d tools ]; then
+	find tools -type f -name '*.sh' | sort | while read -r script; do
+		sh -n "${script}" || exit 1
+	done || FAILED=1
+fi
+
+if command -v shellcheck >/dev/null 2>&1; then
+	printf '%s\n' 'Running ShellCheck advisory checks...'
+	shellcheck installer || true
+	if [ -d tools ]; then
+		find tools -type f -name '*.sh' | sort | while read -r script; do
+			shellcheck "${script}" || true
+		done
+	fi
+else
+	printf '%s\n' 'ShellCheck not found; skipped advisory checks.'
+fi
+
+if [ "${FAILED}" -ne 0 ]; then
+	printf '%s\n' 'Validation failed.'
+	exit 1
+fi
+
+printf '%s\n' 'Validation completed.'


### PR DESCRIPTION
## Summary

This second-pass PR adds validation and planning material after the first helper/documentation branches were merged.

Changes include:

- `tools/README.md` documenting helper scripts and integration rules.
- `tools/validate.sh` for local syntax validation and advisory ShellCheck runs.
- `docs/installer-hardening-roadmap.md` with a phased plan for safely folding helpers into the active installer.

## Runtime impact

No installer runtime behavior is changed.

## Why this is master-safe

This PR only adds documentation and a local validation helper. It does not modify the active `installer` script.

## Suggested next step

After this merges, the next PR should make one small installer change at a time, beginning with exact package matching or safer password hashing.