### PR TITLE
ci: make ShellCheck advisory non-blocking

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -30,15 +30,36 @@ jobs:
   shellcheck:
     name: ShellCheck advisory
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run ShellCheck as advisory only
-        uses: ludeeus/action-shellcheck@master
-        with:
-          scandir: '.'
-          severity: warning
-          check_together: 'yes'
-          ignore_paths: '.git'
+      - name: Install ShellCheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Run ShellCheck advisory report
+        run: |
+          status=0
+
+          echo "Running ShellCheck advisory checks. Warnings are reported below but do not fail this job."
+
+          if [ -f installer ]; then
+            shellcheck --severity=warning installer || status=1
+          fi
+
+          if [ -d tools ]; then
+            find tools -type f -name '*.sh' | sort | while read -r script; do
+              echo "ShellCheck: ${script}"
+              shellcheck --severity=warning "${script}" || true
+            done
+          fi
+
+          if [ "${status}" -ne 0 ]; then
+            echo "ShellCheck found advisory warnings. See log output above."
+          else
+            echo "ShellCheck found no advisory warnings."
+          fi
+
+          exit 0


### PR DESCRIPTION
## Summary

This PR fixes the current GitHub checks behavior where the ShellCheck advisory job still appears as a failed check.

Changes include:

- Replaces the ShellCheck GitHub Action wrapper with a direct `shellcheck` command.
- Keeps ShellCheck output visible in the workflow logs.
- Always exits the advisory job with `0` so it does not mark the commit red.
- Keeps the POSIX `sh -n installer` syntax job as the real required gate.

## Runtime impact

No installer runtime behavior is changed.

## Why

The previous workflow used `continue-on-error: true`, but GitHub still displayed the ShellCheck advisory job as failed. This keeps advisory warnings visible without causing a red failed status.