### PR TITLE
chore: add issue templates for support intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,112 @@
+name: Bug report
+description: Report an installer, update, DNS, or service issue
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting an issue. Please provide enough detail to reproduce the problem.
+
+        If the problem is with AdGuard Home itself rather than this installer, report it upstream first:
+        https://github.com/AdguardTeam/AdGuardHome/issues
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem description
+      description: What happened? What did you expect to happen?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: operation
+    attributes:
+      label: Operation
+      description: Which installer operation were you running?
+      options:
+        - Fresh install
+        - Update
+        - Reconfigure
+        - Uninstall
+        - Backup
+        - Restore
+        - Service start/stop/restart
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: router_model
+    attributes:
+      label: Router model
+      placeholder: RT-AX86U, GT-AX6000, RT-BE88U, etc.
+    validations:
+      required: true
+
+  - type: input
+    id: firmware
+    attributes:
+      label: Asuswrt-Merlin firmware version
+      placeholder: 3004.388.x, 3006.102.x, etc.
+    validations:
+      required: true
+
+  - type: input
+    id: installer_version
+    attributes:
+      label: Installer version
+      placeholder: v2.0.1
+    validations:
+      required: false
+
+  - type: dropdown
+    id: entware
+    attributes:
+      label: Entware status
+      options:
+        - Installed and updated
+        - Installed but not recently updated
+        - Not sure
+        - Not installed
+    validations:
+      required: true
+
+  - type: textarea
+    id: dns_environment
+    attributes:
+      label: DNS/network environment
+      description: Include anything relevant to DNS or routing.
+      placeholder: |
+        - Dual WAN: yes/no
+        - Double NAT: yes/no
+        - VPN Director: yes/no
+        - DNS Director/DNSFilter: yes/no
+        - Stubby/dnscrypt-proxy/other DNS service: yes/no
+        - Another service on port 53: yes/no
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output or logs
+      description: Paste error output here. Review logs before posting and remove private values.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: checks
+    attributes:
+      label: Basic checks
+      description: Paste the output of any commands that apply.
+      value: |
+        ```sh
+        pidof AdGuardHome
+        /opt/etc/init.d/S99AdGuardHome check
+        netstat -lnp | grep ':53 '
+        opkg list-installed | grep -E 'python3|bcrypt|go|AdGuardHome'
+        ```
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: AdGuard Home upstream issues
+    url: https://github.com/AdguardTeam/AdGuardHome/issues
+    about: Report issues with AdGuard Home itself upstream.
+  - name: SNBForums support thread
+    url: http://www.snbforums.com/threads/release-asuswrt-merlin-adguardhome-installer-amaghi.76506/
+    about: Community discussion and support for the installer.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: Feature request
+description: Suggest an installer improvement or new option
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for installer features, maintenance improvements, or Asuswrt-Merlin integration ideas.
+
+  - type: textarea
+    id: feature
+    attributes:
+      label: Feature description
+      description: What should be added or changed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case
+      description: What problem does this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_behavior
+    attributes:
+      label: Proposed behavior
+      description: How should the installer behave?
+    validations:
+      required: false
+
+  - type: input
+    id: router_model
+    attributes:
+      label: Router model, if relevant
+      placeholder: RT-AX86U, GT-AX6000, RT-BE88U, etc.
+    validations:
+      required: false
+
+  - type: input
+    id: firmware
+    attributes:
+      label: Asuswrt-Merlin firmware version, if relevant
+      placeholder: 3004.388.x, 3006.102.x, etc.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Adds GitHub issue templates to improve support intake and reduce back-and-forth when troubleshooting installer problems.

Changes include:

- Bug report template for install/update/reconfigure/service issues.
- Feature request template for installer improvements.
- Issue template config with links to AdGuard Home upstream issues and the SNBForums support thread.

## Runtime impact

No installer runtime behavior is changed.

## Why

Installer issues often depend on router model, firmware, Entware status, DNSFilter/DNS Director, dual WAN, double NAT, VPN Director, and whether another DNS service is using port 53. The bug template asks for that context up front.