### PR TITLE
ci: fix installer hardening workflow target branch setup

### DIFF
--- a/.github/workflows/apply-installer-hardening.yml
+++ b/.github/workflows/apply-installer-hardening.yml
@@ -7,6 +7,14 @@ on:
         description: Branch to update with generated installer hardening changes
         required: true
         default: dev/installer-code-hardening-squash
+      reset_target_from_master:
+        description: Recreate/reset target branch from current master before applying changes
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
 
 permissions:
   contents: write
@@ -16,15 +24,35 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout target branch
+      - name: Checkout master
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.target_branch }}
+          ref: master
+          fetch-depth: 0
+          persist-credentials: true
 
       - name: Configure git identity
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Prepare target branch
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          RESET_TARGET_FROM_MASTER: ${{ inputs.reset_target_from_master }}
+        run: |
+          set -eu
+
+          git fetch origin master
+
+          if [ "${RESET_TARGET_FROM_MASTER}" = "true" ]; then
+            git checkout -B "${TARGET_BRANCH}" origin/master
+          elif git ls-remote --exit-code --heads origin "${TARGET_BRANCH}" >/dev/null 2>&1; then
+            git fetch origin "${TARGET_BRANCH}"
+            git checkout -B "${TARGET_BRANCH}" "origin/${TARGET_BRANCH}"
+          else
+            git checkout -B "${TARGET_BRANCH}" origin/master
+          fi
 
       - name: Apply installer hardening
         run: |
@@ -33,7 +61,7 @@ jobs:
       - name: Ensure installer.md5 exists
         run: |
           if [ -f installer ] && [ ! -f installer.md5 ]; then
-            sh tools/update-md5.sh installer.md5
+            md5sum installer | awk '{print $1 "  installer"}' > installer.md5
           fi
 
       - name: Update changed MD5 files
@@ -63,13 +91,18 @@ jobs:
           fi
 
       - name: Commit generated changes
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
         run: |
+          set -eu
+
           if git diff --quiet; then
             echo "No generated changes to commit."
+            git push --force-with-lease origin HEAD:"${TARGET_BRANCH}"
             exit 0
           fi
 
           git status --short
           git add installer installer.md5 tools docs .github
           git commit -m "installer: apply hardening changes and update checksums"
-          git push origin HEAD:${{ inputs.target_branch }}
+          git push --force-with-lease origin HEAD:"${TARGET_BRANCH}"


### PR DESCRIPTION
## Summary

Fixes the manual installer hardening workflow so it no longer assumes the target branch already exists.

Changes include:

- Checkout `master` first with full history.
- Add `reset_target_from_master` workflow input.
- Create or refresh the selected target branch from `origin/master` when requested.
- Fall back to creating the target branch from `master` if the branch does not exist.
- Push generated changes back with `--force-with-lease` so a reset target branch can be updated safely.
- Generate `installer.md5` directly with `md5sum` if it does not already exist.

## Why

The failed workflow run likely failed during `git` checkout/push because the target branch was missing or had been deleted after a previous PR merge.

## Runtime impact

No installer runtime behavior changes. This only fixes the manual apply workflow.