### PR TITLE
ci: fix installer hardening apply script execution

### DIFF
--- a/.github/workflows/apply-installer-hardening.yml
+++ b/.github/workflows/apply-installer-hardening.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Apply installer hardening
         run: |
-          python3 tools/apply-installer-hardening.py
+          python3 tools/apply-installer-hardening-ci.py
 
       - name: Ensure installer.md5 exists
         run: |

--- a/tools/apply-installer-hardening-ci.py
+++ b/tools/apply-installer-hardening-ci.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""CI-safe wrapper for apply-installer-hardening.py.
+
+The original helper uses pathlib read/write helpers with a newline argument that
+is not supported on every GitHub Actions Python runtime. This wrapper imports the
+existing hardening rules but performs file I/O with built-in open().
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "installer"
+HELPER = ROOT / "tools" / "apply-installer-hardening.py"
+
+
+def main() -> int:
+    if not INSTALLER.exists():
+        print("Error: installer file not found", file=sys.stderr)
+        return 1
+
+    spec = importlib.util.spec_from_file_location("apply_installer_hardening", HELPER)
+    if spec is None or spec.loader is None:
+        print("Error: could not load apply-installer-hardening.py", file=sys.stderr)
+        return 1
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    with INSTALLER.open("r", encoding="utf-8", newline="") as fh:
+        original = fh.read()
+
+    updated, changes = module.harden_installer(original)
+
+    if changes == 0:
+        print("No installer changes were needed.")
+        return 0
+
+    with INSTALLER.open("w", encoding="utf-8", newline="\n") as fh:
+        fh.write(updated)
+
+    print(f"Applied {changes} installer hardening change(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Fixes the manual installer hardening workflow failure at the `Apply installer hardening` step.

Changes include:

- Adds `tools/apply-installer-hardening-ci.py`, a CI-safe wrapper around the existing hardening rules.
- Uses built-in `open(..., newline=...)` for installer file I/O instead of relying on `Path.read_text(..., newline=...)` behavior.
- Updates the workflow to run the CI wrapper.

## Why

The failed run stopped during the apply step before checksum generation or commit. This patch keeps the hardening logic intact while making the workflow execution path compatible with the GitHub Actions Python runtime.

## Runtime impact

No installer runtime behavior changes. This only fixes the manual workflow execution path.