### PR TITLE
ci: repair installer hardening workflow on master

### DIFF
--- a/.github/workflows/apply-installer-hardening.yml
+++ b/.github/workflows/apply-installer-hardening.yml
@@ -7,6 +7,14 @@ on:
         description: Branch to update with generated installer hardening changes
         required: true
         default: dev/installer-code-hardening-squash
+      reset_target_from_master:
+        description: Recreate/reset target branch from current master before applying changes
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
 
 permissions:
   contents: write
@@ -16,24 +24,51 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout target branch
+      - name: Checkout master
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.target_branch }}
+          ref: master
+          fetch-depth: 0
+          persist-credentials: true
 
       - name: Configure git identity
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      - name: Prepare target branch
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          RESET_TARGET_FROM_MASTER: ${{ inputs.reset_target_from_master }}
+        run: |
+          set -eu
+
+          case "${TARGET_BRANCH}" in
+            *'*'*|*'?'*|*'['*|*']'*|'')
+              echo "Invalid target branch: ${TARGET_BRANCH}" >&2
+              exit 1
+              ;;
+          esac
+
+          git fetch origin master
+
+          if [ "${RESET_TARGET_FROM_MASTER}" = "true" ]; then
+            git checkout -B "${TARGET_BRANCH}" origin/master
+          elif git ls-remote --exit-code --heads origin "${TARGET_BRANCH}" >/dev/null 2>&1; then
+            git fetch origin "refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
+            git checkout -B "${TARGET_BRANCH}" "origin/${TARGET_BRANCH}"
+          else
+            git checkout -B "${TARGET_BRANCH}" origin/master
+          fi
+
       - name: Apply installer hardening
         run: |
-          python3 tools/apply-installer-hardening.py
+          python3 tools/apply-installer-hardening-ci.py
 
       - name: Ensure installer.md5 exists
         run: |
           if [ -f installer ] && [ ! -f installer.md5 ]; then
-            sh tools/update-md5.sh installer.md5
+            md5sum installer | awk '{print $1 "  installer"}' > installer.md5
           fi
 
       - name: Update changed MD5 files
@@ -63,13 +98,18 @@ jobs:
           fi
 
       - name: Commit generated changes
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
         run: |
+          set -eu
+
           if git diff --quiet; then
             echo "No generated changes to commit."
+            git push --force-with-lease origin HEAD:"${TARGET_BRANCH}"
             exit 0
           fi
 
           git status --short
           git add installer installer.md5 tools docs .github
           git commit -m "installer: apply hardening changes and update checksums"
-          git push origin HEAD:${{ inputs.target_branch }}
+          git push --force-with-lease origin HEAD:"${TARGET_BRANCH}"

--- a/tools/apply-installer-hardening-ci.py
+++ b/tools/apply-installer-hardening-ci.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""CI-safe wrapper for apply-installer-hardening.py.
+
+This wrapper imports the existing hardening rules but performs installer file I/O
+with built-in open(). It avoids pathlib read_text/write_text keyword differences
+across Python runtimes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "installer"
+HELPER = ROOT / "tools" / "apply-installer-hardening.py"
+
+
+def main() -> int:
+    if not INSTALLER.exists():
+        print("Error: installer file not found", file=sys.stderr)
+        return 1
+
+    spec = importlib.util.spec_from_file_location("apply_installer_hardening", HELPER)
+    if spec is None or spec.loader is None:
+        print("Error: could not load apply-installer-hardening.py", file=sys.stderr)
+        return 1
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    with INSTALLER.open("r", encoding="utf-8", newline="") as fh:
+        original = fh.read()
+
+    updated, changes = module.harden_installer(original)
+
+    if changes == 0:
+        print("No installer changes were needed.")
+        return 0
+
+    with INSTALLER.open("w", encoding="utf-8", newline="\n") as fh:
+        fh.write(updated)
+
+    print(f"Applied {changes} installer hardening change(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Repairs the current `Apply installer hardening` workflow on `master`.

Changes include:

- Checkout `master` first instead of assuming the target branch already exists.
- Create or reset the selected target branch from `origin/master` when requested.
- Validate the `target_branch` input and reject wildcard characters such as `*`.
- Fetch existing target branches by exact `refs/heads/...` refspec.
- Add and use a CI-safe wrapper for the installer hardening script.

## Why

The current workflow on `master` still checks out `${{ inputs.target_branch }}` directly. If the branch is missing, deleted after merge, or entered with a wildcard, checkout fails before the apply script runs.

## Runtime impact

No installer runtime behavior changes. This only fixes the manual workflow so it can generate the installer/checksum hardening branch safely.