### PR TITLE
installer: use which in phase 3 safe download helper

### DIFF
--- a/tools/apply-installer-hardening-phase3.py
+++ b/tools/apply-installer-hardening-phase3.py
@@ -57,14 +57,14 @@ safe_download() {
 
 	rm -f "${_tmp_output}"
 
-	if command -v curl >/dev/null 2>&1; then
+	if which curl >/dev/null 2>&1; then
 		if curl --retry 5 --connect-timeout 25 --retry-delay 5 --max-time $((5 * 25)) --retry-connrefused -fsL "${_url}" -o "${_tmp_output}" && [ -s "${_tmp_output}" ]; then
 			mv "${_tmp_output}" "${_output}"
 			return 0
 		fi
 	fi
 
-	if command -v wget >/dev/null 2>&1; then
+	if which wget >/dev/null 2>&1; then
 		if wget --no-cache --no-cookies --tries=5 --timeout=25 --waitretry=5 -q "${_url}" -O "${_tmp_output}" && [ -s "${_tmp_output}" ]; then
 			mv "${_tmp_output}" "${_output}"
 			return 0


### PR DESCRIPTION
## Summary

Updates the staged phase 3 installer hardening script so generated router-side installer code uses `which` instead of `command -v`.

## Why

Asuswrt-Merlin router shells may not provide the POSIX `command` builtin:

```text
-sh: command: not found
```

The router environment does provide `which`, so the generated `safe_download()` helper should use `which curl` and `which wget`.

## Runtime impact

No installer runtime behavior changes until phase 3 is generated and merged. This prevents the phase 3 generated installer from introducing a router-side incompatibility.