### PR TITLE
installer: stage phase 4 hardening workflow

### DIFF
--- a/.github/workflows/apply-installer-hardening.yml
+++ b/.github/workflows/apply-installer-hardening.yml
@@ -24,6 +24,7 @@ on:
           - phase1
           - phase2
           - phase3
+          - phase4
 
 permissions:
   contents: write
@@ -85,6 +86,9 @@ jobs:
               ;;
             phase3)
               python3 tools/apply-installer-hardening-phase3.py
+              ;;
+            phase4)
+              python3 tools/apply-installer-hardening-phase4.py
               ;;
             *)
               echo "Unknown hardening phase: ${HARDENING_PHASE}" >&2

--- a/tools/apply-installer-hardening-phase4.py
+++ b/tools/apply-installer-hardening-phase4.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Apply phase 4 targeted installer hardening changes.
+
+This phase focuses on credential-input validation and safer cleanup behavior.
+The script uses exact-context replacements only and exits on ambiguous matches.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "installer"
+
+
+def fail(message: str) -> None:
+    print(f"Error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> tuple[str, bool]:
+    count = text.count(old)
+    if count == 0:
+        print(f"SKIP: {label} already applied or context not found")
+        return text, False
+    if count != 1:
+        fail(f"{label}: expected one match, found {count}")
+    print(f"APPLY: {label}")
+    return text.replace(old, new, 1), True
+
+
+def harden_phase4(text: str) -> tuple[str, int]:
+    changes = 0
+
+    old = '''AdGuardHome_authen() {
+\tlocal USERNAME PW1 PW2
+\tPTXT -n "${INPUT} Please enter AdGuardHome username${NORM}: "
+\tread -r USERNAME
+\twhile :; do
+'''
+    new = '''AdGuardHome_authen() {
+\tlocal USERNAME PW1 PW2
+\twhile :; do
+\t\tPTXT -n "${INPUT} Please enter AdGuardHome username${NORM}: "
+\t\tread -r USERNAME
+\t\tcase "${USERNAME}" in
+\t\t''|*[!A-Za-z0-9._-]*)
+\t\t\tPTXT "${ERROR} Username must contain only letters, numbers, dots, underscores, or hyphens."
+\t\t\t;;
+\t\t*)
+\t\t\tbreak
+\t\t\t;;
+\t\tesac
+\tdone
+\twhile :; do
+'''
+    text, changed = replace_once(text, old, new, "validate AdGuard Home username before YAML insertion")
+    changes += int(changed)
+
+    old = '''\t\tgo install gophers.dev/cmds/bcrypt-tool@latest >/dev/null 2>&1
+\t\trm -rf go
+\telse
+'''
+    new = '''\t\tgo install gophers.dev/cmds/bcrypt-tool@latest >/dev/null 2>&1
+\t\trm -rf "${HOME:-/tmp}/go"
+\telse
+'''
+    text, changed = replace_once(text, old, new, "clean Go workspace from HOME instead of relative path")
+    changes += int(changed)
+
+    old = '''\tlocal PW1_ENCRYPTED
+\tif opkg_installed python3-bcrypt; then PW1_ENCRYPTED="$(printf '%s' "${PW1}" | hash_password_python3)"; elif [ -f "/opt/bin/bcrypt-tool" ]; then PW1_ENCRYPTED="$(/opt/bin/bcrypt-tool hash "${PW1}" 10)"; else
+\t\tPTXT "${ERROR} Password could not be set!" "${ERROR} Please contact dev."
+\t\tend_op_message 1
+\t\treturn
+\tfi
+\tif [ "$1" -eq 0 ]; then
+'''
+    new = '''\tlocal PW1_ENCRYPTED
+\tif opkg_installed python3-bcrypt; then PW1_ENCRYPTED="$(printf '%s' "${PW1}" | hash_password_python3)"; elif [ -f "/opt/bin/bcrypt-tool" ]; then PW1_ENCRYPTED="$(/opt/bin/bcrypt-tool hash "${PW1}" 10)"; else
+\t\tPTXT "${ERROR} Password could not be set!" "${ERROR} Please contact dev."
+\t\tend_op_message 1
+\t\treturn
+\tfi
+\tif [ -z "${PW1_ENCRYPTED}" ]; then
+\t\tPTXT "${ERROR} Password hash could not be generated!" "${ERROR} Please contact dev."
+\t\tend_op_message 1
+\t\treturn
+\tfi
+\tif [ "$1" -eq 0 ]; then
+'''
+    text, changed = replace_once(text, old, new, "validate generated password hash before writing YAML")
+    changes += int(changed)
+
+    old = '''\t\tif ! tar -tzf "${BASE_DIR}/backup_AdGuardHome.tar.gz" >/dev/null 2>&1; then
+\t\t\tPTXT "${ERROR} Backup archive is invalid or unreadable."
+\t\t\tend_op_message 1
+\t\t\treturn
+\t\tfi
+\t\ttar -xzvf "${BASE_DIR}/backup_AdGuardHome.tar.gz" -C "${BASE_DIR}" >/dev/null 2>&1
+'''
+    new = '''\t\tif ! tar -tzf "${BASE_DIR}/backup_AdGuardHome.tar.gz" >/dev/null 2>&1; then
+\t\t\tPTXT "${ERROR} Backup archive is invalid or unreadable."
+\t\t\tend_op_message 1
+\t\t\treturn
+\t\tfi
+\t\tif ! tar -xzvf "${BASE_DIR}/backup_AdGuardHome.tar.gz" -C "${BASE_DIR}" >/dev/null 2>&1; then
+\t\t\tPTXT "${ERROR} Backup archive could not be restored."
+\t\t\tend_op_message 1
+\t\t\treturn
+\t\tfi
+'''
+    text, changed = replace_once(text, old, new, "fail cleanly if backup extraction fails")
+    changes += int(changed)
+
+    return text, changes
+
+
+def main() -> int:
+    if not INSTALLER.exists():
+        print("Error: installer file not found", file=sys.stderr)
+        return 1
+
+    with INSTALLER.open("r", encoding="utf-8", newline="") as fh:
+        original = fh.read()
+
+    updated, changes = harden_phase4(original)
+
+    if changes == 0:
+        print("No phase 4 installer changes were needed.")
+        return 0
+
+    with INSTALLER.open("w", encoding="utf-8", newline="\n") as fh:
+        fh.write(updated)
+
+    print(f"Applied {changes} phase 4 installer hardening change(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Stages the fourth installer-focused hardening batch using the existing manual CI apply workflow pattern.

Changes include:

- Adds `tools/apply-installer-hardening-phase4.py`.
- Adds `phase4` to the `hardening_phase` workflow input.

## Phase 4 installer hardening targets

The phase 4 apply script performs exact-context edits for:

- Validate the AdGuard Home username before writing it into YAML.
- Reject empty or unsafe usernames that contain characters outside letters, numbers, dots, underscores, and hyphens.
- Validate that password hashing produced a non-empty hash before writing YAML.
- Clean the Go workspace from `${HOME:-/tmp}/go` instead of a relative `go` path.
- Fail cleanly if backup extraction fails after archive validation.

## Router compatibility

This phase does not introduce `command -v` into generated router-side installer code.

## How to apply after merge

Run the manual workflow:

- Workflow: `Apply installer hardening`
- `target_branch`: `dev/installer-code-hardening-squash`
- `reset_target_from_master`: `true`
- `hardening_phase`: `phase4`

The workflow will generate the installer changes, update `installer.md5sum`, validate checksums, run POSIX syntax validation, and push the generated branch for review.

## Runtime impact

This PR only stages the apply script/workflow input. Installer runtime behavior changes only after the manual workflow generates the installer/checksum commit and that generated PR is merged.