### PR TITLE
ci: add router compatibility guard

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -27,6 +27,10 @@ jobs:
             find tools -type f -name '*.sh' -print -exec sh -n {} \;
           fi
 
+      - name: Check router compatibility
+        run: |
+          sh tools/check-router-compat.sh installer
+
       - name: Check md5sum files
         run: |
           if find . -type f -name '*.md5sum' ! -path './.git/*' | grep -q .; then

--- a/tools/check-router-compat.sh
+++ b/tools/check-router-compat.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Check generated router-side installer code for known Asuswrt shell incompatibilities.
+# BusyBox/ash-compatible.
+
+set -u
+
+TARGET_FILE="${1:-installer}"
+FAILED=0
+TMP_PREFIX="/tmp/router-compat.$$"
+
+cleanup() {
+	rm -f "${TMP_PREFIX}.command-v" "${TMP_PREFIX}.md5" "${TMP_PREFIX}.rmrf"
+}
+trap cleanup EXIT HUP INT TERM
+
+if [ ! -f "${TARGET_FILE}" ]; then
+	printf '%s\n' "Error: ${TARGET_FILE} not found" >&2
+	exit 1
+fi
+
+if grep -n 'command -v ' "${TARGET_FILE}" >"${TMP_PREFIX}.command-v" 2>/dev/null; then
+	printf '%s\n' "Error: ${TARGET_FILE} contains command -v, which is not available on target Asuswrt shells:" >&2
+	cat "${TMP_PREFIX}.command-v" >&2
+	FAILED=1
+fi
+
+if grep -n 'installer\.md5\>' "${TARGET_FILE}" >"${TMP_PREFIX}.md5" 2>/dev/null; then
+	printf '%s\n' "Error: ${TARGET_FILE} references installer.md5 instead of installer.md5sum:" >&2
+	cat "${TMP_PREFIX}.md5" >&2
+	FAILED=1
+fi
+
+if grep -n 'rm -rf[[:space:]].*\$\$' "${TARGET_FILE}" >"${TMP_PREFIX}.rmrf" 2>/dev/null; then
+	printf '%s\n' "Error: ${TARGET_FILE} uses rm -rf against a process-id temporary path:" >&2
+	cat "${TMP_PREFIX}.rmrf" >&2
+	FAILED=1
+fi
+
+if [ "${FAILED}" -ne 0 ]; then
+	exit 1
+fi
+
+printf '%s\n' "OK: ${TARGET_FILE} passed router compatibility guard checks."


### PR DESCRIPTION
## Summary

Adds a router compatibility guard for generated router-side installer code and wires it into the existing shell validation workflow.

## Checks added

`tools/check-router-compat.sh` fails if `installer` contains known target-router incompatibilities:

- `command -v`, because Asuswrt shells may not provide the `command` builtin.
- `installer.md5`, because the repo uses `installer.md5sum`.
- `rm -rf` against process-id temporary paths.

## CI integration

The existing Shell validation workflow now runs:

```sh
sh tools/check-router-compat.sh installer
```

alongside syntax and checksum checks.

## Runtime impact

No installer runtime behavior changes. This is a repository/CI guard to prevent future incompatible installer code from being merged.