### PR TITLE
ci: auto-update matching md5sum files

### DIFF
--- a/.github/workflows/update-md5sum-files.yml
+++ b/.github/workflows/update-md5sum-files.yml
@@ -1,0 +1,52 @@
+name: Update matching md5sum files
+
+on:
+  push:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-md5sum-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  update-md5sum:
+    name: Update matching .md5sum files
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'branch'
+
+    steps:
+      - name: Checkout pushed branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Update all matching .md5sum files
+        run: |
+          set -eu
+          sh tools/update-md5.sh
+
+      - name: Commit md5sum updates
+        run: |
+          set -eu
+
+          if git diff --quiet -- '*.md5sum'; then
+            echo "No .md5sum updates needed."
+            exit 0
+          fi
+
+          git status --short
+          git add '*.md5sum' '**/*.md5sum'
+          git commit -m "chore: update matching md5sum files"
+          git push

--- a/tools/update-changed-md5.sh
+++ b/tools/update-changed-md5.sh
@@ -21,6 +21,12 @@ MODE="changed"
 FAILED=0
 UPDATED=0
 SEEN_FILES=""
+FILES_TMP="/tmp/update-changed-md5.$$"
+
+cleanup() {
+	rm -f "${FILES_TMP}"
+}
+trap cleanup EXIT HUP INT TERM
 
 calc_md5() {
 	_file="$1"
@@ -80,28 +86,37 @@ update_for_source() {
 		return 1
 	fi
 
+	_current_value=""
+	if [ -f "${_md5_file}" ]; then
+		_current_value="$(awk 'NF {print $1; exit}' "${_md5_file}")"
+	fi
+
+	if [ "${_current_value}" = "${_md5_value}" ]; then
+		return 0
+	fi
+
 	printf '%s\n' "${_md5_value}" >"${_md5_file}"
 	printf '%s\n' "Updated ${_md5_file}: ${_md5_value}"
 	UPDATED="$((UPDATED + 1))"
 }
 
-process_git_changed_files() {
+write_git_changed_files() {
 	case "${MODE}" in
 	staged)
-		git diff --cached --name-only --diff-filter=ACMR
+		git diff --cached --name-only --diff-filter=ACMR >"${FILES_TMP}"
 		;;
 	all)
 		{
 			git diff --name-only --diff-filter=ACMR
 			git diff --cached --name-only --diff-filter=ACMR
 			git ls-files --others --exclude-standard
-		} | sort -u
+		} | sort -u >"${FILES_TMP}"
 		;;
 	changed|*)
 		{
 			git diff --name-only --diff-filter=ACMR
 			git diff --cached --name-only --diff-filter=ACMR
-		} | sort -u
+		} | sort -u >"${FILES_TMP}"
 		;;
 	esac
 }
@@ -142,9 +157,10 @@ else
 		exit 1
 	fi
 
-	process_git_changed_files | while read -r src_file; do
-		update_for_source "${src_file}" || exit 1
-	done || FAILED=1
+	write_git_changed_files
+	while IFS= read -r src_file; do
+		update_for_source "${src_file}" || FAILED=1
+	done <"${FILES_TMP}"
 fi
 
 if [ "${FAILED}" -ne 0 ]; then


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically updates checksum sidecar files whenever a tracked file with a matching `.md5sum` sidecar changes.

## Behavior

For every file matching this pattern:

```text
path/to/file
path/to/file.md5sum
```

GitHub Actions recomputes the MD5 of `path/to/file` and commits the raw checksum back into `path/to/file.md5sum`.

This applies to `installer`/`installer.md5sum` and any future file that has a corresponding `.md5sum` file.

## Added workflow

```text
.github/workflows/update-md5sum-files.yml
```

The workflow runs on pushes to branches and can also be run manually.

## Tooling cleanup

Also fixes `tools/update-changed-md5.sh` so its `UPDATED` and `FAILED` counters are preserved outside the file-list loop. The previous pipeline form could run the updater in a subshell, making the final status message inaccurate.

## Notes

The checksum file format remains unchanged: raw hash only, no filename.