### PR TITLE
Improve DNS port ownership checks and pid killing in AdGuardHome init script

### DIFF
--- a/S99AdGuardHome
+++ b/S99AdGuardHome
@@ -18,15 +18,24 @@ PREARGS="env TZ=/etc/localtime GOGC=${GOGC} GOMAXPROCS=${GOMAXPROCS} GOMEMLIMIT=
 adguardhome_owns_dns() {
 	pidof "${PROCS}" >/dev/null 2>&1 || return 1
 	netstat -nlp 2>/dev/null | awk -v proc="${PROCS}" '
-		$0 ~ /^(tcp|udp)6?[[:space:]]+/ && $0 ~ /:53[[:space:]]/ && $0 ~ "/" proc "([[:space:]]|$)" { found=1 }
-		END { exit(found ? 0 : 1) }
+		$0 ~ /^(tcp)6?[[:space:]]+/ && $0 ~ /:53[[:space:]]/ {
+			if ($0 ~ "/" proc "([[:space:]]|$)") tcp_found=1; else other_found=1
+		}
+		$0 ~ /^(udp)6?[[:space:]]+/ && $0 ~ /:53[[:space:]]/ {
+			if ($0 ~ "/" proc "([[:space:]]|$)") udp_found=1; else other_found=1
+		}
+		END { exit(tcp_found && udp_found && !other_found ? 0 : 1) }
 	'
 }
 
 kill_dns_port_owners() {
 	_dns_pids="$(netstat -nlp 2>/dev/null | awk -v proc="${PROCS}" '
-		$0 ~ /:53[[:space:]]/ && $0 !~ "/" proc "([[:space:]]|$)" {
+		$0 ~ /^(tcp)6?[[:space:]]+/ && $0 ~ /:53[[:space:]]/ && $0 !~ "/" proc "([[:space:]]|$)" {
 			split($7, pid_parts, "/")
+			if (pid_parts[1] ~ /^[0-9]+$/ && !seen[pid_parts[1]]++) printf "%s ", pid_parts[1]
+		}
+		$0 ~ /^(udp)6?[[:space:]]+/ && $0 ~ /:53[[:space:]]/ && $0 !~ "/" proc "([[:space:]]|$)" {
+			split($6, pid_parts, "/")
 			if (pid_parts[1] ~ /^[0-9]+$/ && !seen[pid_parts[1]]++) printf "%s ", pid_parts[1]
 		}
 	')"


### PR DESCRIPTION
### Motivation
- Ensure AdGuard Home only proceeds when it exclusively owns both TCP and UDP DNS listeners on port 53 and avoid killing unrelated or self PIDs found in `netstat` output.

### Description
- Tighten `adguardhome_owns_dns()` awk logic to require the process to own both TCP and UDP port 53 listeners and to detect any other owners before returning success.
- Update `kill_dns_port_owners()` awk logic to separately parse TCP and UDP `netstat` lines and extract the correct PID column for each protocol while deduplicating PIDs before killing.
- Preserve existing environment and resource limits while improving robustness of port-owner detection across IPv4/IPv6 and protocol types.

### Testing
- Performed a shell syntax check with `sh -n S99AdGuardHome`, which succeeded.
- Executed the repository's init-script integration tests that mock `netstat` outputs to exercise DNS ownership and kill paths, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffd0ee8b208329b6f61a4217614e53)