### PR TITLE
Enhance code-quality checks, shfmt handling, and Codex prompt with local output

### DIFF
--- a/.github/prompts/codex-code-improvement.md
+++ b/.github/prompts/codex-code-improvement.md
@@ -14,8 +14,10 @@ Review scope:
 Useful local checks:
 - `tools/code-quality.sh`
 - `tools/check-md5.sh`
-- `tools/list-shell-scripts.sh | xargs shellcheck`
-- `tools/list-shell-scripts.sh | xargs shfmt -d`
+- `tools/list-shell-scripts.sh | xargs shellcheck -s sh --severity=warning`
+- `tools/list-shell-scripts.sh | xargs shfmt -d -ln mksh -i 0 -ci`
+
+The runtime prompt includes the latest `tools/code-quality.sh` output. If that output shows `shfmt` formatting differences, call out the exact failing formatting check and recommend running `tools/code-quality.sh --fix` locally or the `Create shfmt formatting PR` workflow against the pull request branch.
 
 Response format:
 1. Start with a short risk summary.

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -28,3 +28,12 @@ jobs:
 
       - name: Run code quality checks
         run: tools/code-quality.sh
+
+      - name: Explain formatting remediation
+        if: failure()
+        run: |
+          {
+            printf '%s\n' '## Code quality remediation'
+            printf '%s\n' ''
+            printf '%s\n' 'If the failure above is from `shfmt`, run `tools/code-quality.sh --fix` locally and commit the formatting changes, or dispatch the `Create shfmt formatting PR` workflow against this branch.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/codex-code-improvement.yml
+++ b/.github/workflows/codex-code-improvement.yml
@@ -87,9 +87,15 @@ jobs:
           sudo apt-get install -y shellcheck shfmt
 
       - name: Run local code quality checks
+        id: local-quality
         if: steps.changed-files.outputs.should_run == 'true'
-        continue-on-error: true
-        run: tools/code-quality.sh
+        run: |
+          set +e
+          tools/code-quality.sh > codex-code-quality.log 2>&1
+          status=$?
+          cat codex-code-quality.log
+          printf 'exit_code=%s\n' "$status" >>"$GITHUB_OUTPUT"
+          exit 0
 
       - name: Compose Codex prompt
         if: steps.changed-files.outputs.should_run == 'true' && env.HAS_OPENAI_API_KEY == 'true'
@@ -108,6 +114,13 @@ jobs:
             printf '%s\n' "- Base SHA: $BASE_SHA"
             printf '%s\n' "- Head SHA: $HEAD_SHA"
             printf '%s\n' "- Extra instructions: $EXTRA_INSTRUCTIONS"
+            printf '%s\n' "- Local code quality exit code: ${{ steps.local-quality.outputs.exit_code || 'not-run' }}"
+            printf '\nLocal code quality output:\n'
+            if [ -f codex-code-quality.log ]; then
+              cat codex-code-quality.log
+            else
+              printf '%s\n' 'No local code quality log was produced.'
+            fi
           } >> .github/prompts/codex-runtime.md
 
       - name: Skip Codex when API key is unavailable

--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ To apply `shfmt` formatting locally, run:
 tools/code-quality.sh --fix
 ```
 
-Pull requests that change shell scripts, checksum files, tools, prompts, or workflows are also reviewed by the Codex Code Improvement workflow when the repository has an `OPENAI_API_KEY` Actions secret configured.
+If CI reports `shfmt` formatting differences, you can also run the `Create shfmt formatting PR` workflow against the affected branch to open an automated formatting pull request.
+
+Pull requests that change shell scripts, checksum files, tools, prompts, or workflows are also reviewed by the Codex Code Improvement workflow when the repository has an `OPENAI_API_KEY` Actions secret configured. The Codex prompt includes the local code-quality output so formatting failures can be reported with the same remediation steps shown in CI.
 
 ## Project notes
 

--- a/tools/check-md5.sh
+++ b/tools/check-md5.sh
@@ -5,7 +5,6 @@
 set -u
 
 FAILED=0
-TARGETS="installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome"
 
 have_cmd() {
 	which "$1" >/dev/null 2>&1
@@ -80,11 +79,11 @@ validate_one() {
 	printf '%s\n' "OK: ${_md5_file} matches ${_src_file}"
 }
 
-if [ "$#" -gt 0 ]; then
-	TARGETS="$*"
+if [ "$#" -eq 0 ]; then
+	set -- installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome
 fi
 
-for target in ${TARGETS}; do
+for target do
 	validate_one "${target}" || true
 done
 

--- a/tools/code-quality.sh
+++ b/tools/code-quality.sh
@@ -54,6 +54,8 @@ run_script_list_check() {
 		printf '%s\n' "FAILED: ${_name}" >&2
 		FAILED=1
 	fi
+
+	return "${_check_failed}"
 }
 
 require_cmd() {
@@ -85,14 +87,19 @@ fi
 run_check 'md5sum files match installer artifacts' sh tools/check-md5.sh
 
 if require_cmd shellcheck; then
-	run_script_list_check 'ShellCheck static analysis' shellcheck
+	run_script_list_check 'ShellCheck POSIX sh static analysis' shellcheck -s sh --severity=warning
 fi
 
 if require_cmd shfmt; then
+	SHFMT_FAILED=0
 	if [ "${FIX}" -eq 1 ]; then
-		run_script_list_check 'shfmt formatting update' shfmt -w
+		run_script_list_check 'shfmt mksh formatting update' shfmt -w -ln mksh -i 0 -ci || SHFMT_FAILED=1
 	else
-		run_script_list_check 'shfmt formatting check' shfmt -d
+		run_script_list_check 'shfmt mksh formatting check' shfmt -d -ln mksh -i 0 -ci || SHFMT_FAILED=1
+	fi
+
+	if [ "${SHFMT_FAILED}" -ne 0 ] && [ "${FIX}" -eq 0 ]; then
+		printf '%s\n' 'Hint: shfmt reported formatting differences. Run tools/code-quality.sh --fix locally, or run the Create shfmt formatting PR workflow against this branch.' >&2
 	fi
 fi
 

--- a/tools/update-md5.sh
+++ b/tools/update-md5.sh
@@ -6,7 +6,6 @@ set -u
 
 FAILED=0
 UPDATED=0
-TARGETS="installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome"
 
 have_cmd() {
 	which "$1" >/dev/null 2>&1
@@ -76,11 +75,11 @@ update_one() {
 	UPDATED="$((UPDATED + 1))"
 }
 
-if [ "$#" -gt 0 ]; then
-	TARGETS="$*"
+if [ "$#" -eq 0 ]; then
+	set -- installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome
 fi
 
-for target in ${TARGETS}; do
+for target do
 	update_one "${target}" || true
 done
 


### PR DESCRIPTION
### Motivation
- Improve repository code-quality tooling to provide clearer shfmt remediation steps and more accurate formatting checks.
- Make the Codex code-review prompt include local code-quality output so automated reviews can report formatting failures and diagnostics.
- Make MD5 helper scripts handle optional positional arguments more robustly when invoked with explicit targets.

### Description
- Updated `.github/prompts/codex-code-improvement.md` to run `shellcheck` with `-s sh --severity=warning`, run `shfmt` with stricter mksh options in checks, and instruct the reviewer to call out exact shfmt failures and remediation steps.
- Enhanced `/.github/workflows/code-quality.yml` to append a human-friendly remediation block to the step summary when formatting checks fail.
- Changed `.github/workflows/codex-code-improvement.yml` to capture the output and exit code of `tools/code-quality.sh` into `codex-code-quality.log` and include that log and exit code in the Codex runtime prompt.
- Modified `tools/code-quality.sh` to run `shellcheck` with POSIX sh settings, run `shfmt` using `-ln mksh -i 0 -ci`, report shfmt-specific failures via a hint message, and return a failure code when checks fail.
- Adjusted `tools/check-md5.sh` and `tools/update-md5.sh` to use positional parameters when no arguments are provided and iterate with `for target do` to allow optional target arguments while keeping BusyBox/ash compatibility.
- Updated `README.md` to mention the `Create shfmt formatting PR` workflow and that the Codex prompt includes local code-quality output for easier remediation.

### Testing
- No automated CI runs were executed as part of this change in the provided rollout transcript; CI workflows were updated to run `tools/code-quality.sh` and to collect logs and remediation hints when triggered.
- Manual invocation of `tools/code-quality.sh` is supported and the scripts now emit a clear hint when `shfmt` reports formatting differences and provide an option to run `tools/code-quality.sh --fix`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00096edb5483299ec1a0b8fe528fbc)