### PR TITLE
chore: include tarball md5sum files in updater

### DIFF
--- a/.github/workflows/shell-validation.yml
+++ b/.github/workflows/shell-validation.yml
@@ -108,23 +108,25 @@ jobs:
 
           target_branch="${{ github.event.pull_request.head.ref }}"
           original_sha="${{ github.event.pull_request.head.sha }}"
-          md5_files=(
-            installer.md5sum
-            AdGuardHome.sh.md5sum
-            S99AdGuardHome.md5sum
-            rc.func.AdGuardHome.md5sum
-          )
+          md5_files=(installer.md5sum AdGuardHome.sh.md5sum S99AdGuardHome.md5sum rc.func.AdGuardHome.md5sum)
+          md5_targets=(installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome)
+          while IFS= read -r archive; do
+            md5_files+=("${archive}.md5sum")
+            md5_targets+=("${archive}")
+          done < <(find armv5 armv7 armv8 -maxdepth 1 -type f -name '*.tar.gz' | sort)
 
-          busybox ash tools/update-md5.sh installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome
+          busybox ash tools/update-md5.sh "${md5_targets[@]}"
 
-          if git diff --quiet -- "${md5_files[@]}"; then
+          if [ -z "$(git status --porcelain -- "${md5_files[@]}")" ]; then
             echo "MD5 files are already current on the checked-out PR head."
             git reset --hard
+            git clean -f -- "${md5_files[@]}"
             exit 0
           fi
 
           echo "MD5 files are stale on ${original_sha}. Waiting for update-md5sum chore commit on ${target_branch}."
           git reset --hard
+          git clean -f -- "${md5_files[@]}"
 
           for attempt in $(seq 1 30); do
             git fetch --quiet origin "${target_branch}"
@@ -147,8 +149,16 @@ jobs:
           exit 1
 
       - name: Validate md5sum files with BusyBox ash
+        shell: bash
         run: |
-          busybox ash tools/check-md5.sh installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome
+          set -euo pipefail
+
+          md5_targets=(installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome)
+          while IFS= read -r archive; do
+            md5_targets+=("${archive}")
+          done < <(find armv5 armv7 armv8 -maxdepth 1 -type f -name '*.tar.gz' | sort)
+
+          busybox ash tools/check-md5.sh "${md5_targets[@]}"
 
   shfmt:
     name: shfmt mksh recommendations

--- a/.github/workflows/update-md5sum.yml
+++ b/.github/workflows/update-md5sum.yml
@@ -10,6 +10,12 @@ on:
       - AdGuardHome.sh
       - S99AdGuardHome
       - rc.func.AdGuardHome
+      - 'armv5/*.tar.gz'
+      - 'armv5/*.tar.gz.md5sum'
+      - 'armv7/*.tar.gz'
+      - 'armv7/*.tar.gz.md5sum'
+      - 'armv8/*.tar.gz'
+      - 'armv8/*.tar.gz.md5sum'
       - tools/update-md5.sh
       - .github/workflows/update-md5sum.yml
   workflow_dispatch:
@@ -67,20 +73,33 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Update md5sum files
+        shell: bash
         run: |
-          sh tools/update-md5.sh installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome
+          set -euo pipefail
+
+          md5_targets=(installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome)
+          while IFS= read -r archive; do
+            md5_targets+=("${archive}")
+          done < <(find armv5 armv7 armv8 -maxdepth 1 -type f -name '*.tar.gz' | sort)
+
+          sh tools/update-md5.sh "${md5_targets[@]}"
 
       - name: Commit md5sum updates
         shell: bash
         run: |
           set -euo pipefail
 
-          if git diff --quiet -- installer.md5sum AdGuardHome.sh.md5sum S99AdGuardHome.md5sum rc.func.AdGuardHome.md5sum; then
+          md5_files=(installer.md5sum AdGuardHome.sh.md5sum S99AdGuardHome.md5sum rc.func.AdGuardHome.md5sum)
+          while IFS= read -r archive; do
+            md5_files+=("${archive}.md5sum")
+          done < <(find armv5 armv7 armv8 -maxdepth 1 -type f -name '*.tar.gz' | sort)
+
+          if [ -z "$(git status --porcelain -- "${md5_files[@]}")" ]; then
             echo "No md5sum updates needed."
             exit 0
           fi
 
-          git status --short
-          git add installer.md5sum AdGuardHome.sh.md5sum S99AdGuardHome.md5sum rc.func.AdGuardHome.md5sum
+          git status --short -- "${md5_files[@]}"
+          git add "${md5_files[@]}"
           git commit -m "chore: update md5sum files"
           git push origin HEAD:${{ steps.branch.outputs.target }}


### PR DESCRIPTION
### Motivation
- Ensure AdGuardHome static archive tarballs and their `.tar.gz.md5sum` sidecars are included in the automatic md5sum updater. 
- Allow the updater workflow to discover existing architecture-specific archives and generate or refresh their md5 sidecars. 
- Extend PR validation to detect newly-created archive sidecars, validate discovered archives, and avoid race conditions while waiting for the updater chore commit.

### Description
- Added path triggers for `armv5/*.tar.gz`, `armv5/*.tar.gz.md5sum`, `armv7/*.tar.gz`, `armv7/*.tar.gz.md5sum`, `armv8/*.tar.gz`, and `armv8/*.tar.gz.md5sum` in `.github/workflows/update-md5sum.yml`. 
- Updated the update job to discover archives with `find armv5 armv7 armv8 -maxdepth 1 -type f -name '*.tar.gz' | sort`, build a `md5_targets` array, and call `sh tools/update-md5.sh "${md5_targets[@]}"` so sidecars are created/updated for discovered tarballs. 
- Adjusted the commit step to assemble a `md5_files` list that includes discovered `*.tar.gz.md5sum` sidecars, use `git status --porcelain` to detect changes, and `git add "${md5_files[@]}"` to include newly-created sidecars in the chore commit. 
- Extended `.github/workflows/shell-validation.yml` to discover archives for PR waiting, run `tools/update-md5.sh` for discovered targets, `git clean -f -- "${md5_files[@]}"` to remove generated sidecars when appropriate, and run `busybox ash tools/check-md5.sh "${md5_targets[@]}"` to validate archive checksums; converted a few steps to run under `bash` with `set -euo pipefail` for robustness.

### Testing
- Ran `sh tools/update-md5.sh installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome` and confirmed existing `.md5sum` files were current. (success)
- Ran `sh tools/check-md5.sh installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome` and confirmed checksums matched. (success)
- Performed a temporary archive smoke test by creating `armv5/AdGuardHome_test_linux_armv5.tar.gz` and verified `armv5/AdGuardHome_test_linux_armv5.tar.gz.md5sum` was generated and detected by the updater. (success)
- Validated the modified YAML files via Ruby (`ruby -e 'require "yaml"; ...'`) which loaded both workflows successfully. (success)
- Attempted YAML validation with Python `yaml.safe_load` but the environment lacked `PyYAML`. (skipped due to missing dependency)
- Ran `sh tools/code-quality.sh` which completed md5 validation but could not finish full checks because `shellcheck` and `shfmt` are not installed in this environment. (partial)
- Ran `git diff --check` with no actionable warnings. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f3262488883299706d583a3d6cbb3)