### PR TITLE
Preserve successful legacy hook cleanup status

### DIFF
--- a/installer
+++ b/installer
@@ -1498,16 +1498,23 @@ del_jffs_script() {
 		LINE_NUM="$(grep -n -F "[ -x ${ADDON_DIR}/" "${TARG}" | cut -d':' -f1)"
 	fi
 	[ -z "${LINE_NUM}" ] && return
-	printf "%s\n" "${LINE_NUM}" | sort -rn | while IFS= read -r LINE_NUM; do
+	LINE_NUM="$(printf "%s\n" "${LINE_NUM}" | sort -rn)" || return 1
+	for LINE_NUM in ${LINE_NUM}; do
 		[ -z "${LINE_NUM}" ] && continue
-		sed -i "${LINE_NUM}d" "${TARG}"
+		sed -i "${LINE_NUM}d" "${TARG}" || return 1
 		if [ "${LINE_NUM}" -gt 1 ]; then
 			LINE_NUM="$((LINE_NUM - 1))"
-			LINE_ABOVE="$(sed "${LINE_NUM}q;d" "${TARG}")"
-			[ -z "${LINE_ABOVE}" ] && sed -i "${LINE_NUM}d" "${TARG}"
+			LINE_ABOVE="$(sed "${LINE_NUM}q;d" "${TARG}")" || return 1
+			if [ -z "${LINE_ABOVE}" ]; then
+				sed -i "${LINE_NUM}d" "${TARG}" || return 1
+			fi
 		fi
 	done
-	[ "$(awk '{ print }' "${TARG}")" = "#!/bin/sh" ] && rm -f "${TARG}"
+	LINE_ABOVE="$(awk '{ print }' "${TARG}")" || return 1
+	if [ "${LINE_ABOVE}" = "#!/bin/sh" ]; then
+		rm -f "${TARG}" || return 1
+	fi
+	return 0
 }
 
 download_file() {

--- a/installer.md5sum
+++ b/installer.md5sum
@@ -1,1 +1,1 @@
-af57859b6e8a46bdff4702ed1fb1095e  installer
+06d07ae24fc0bd5591958c156b4452a2  installer

--- a/tests/installer-legacy-hook-cleanup.sh
+++ b/tests/installer-legacy-hook-cleanup.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Verify legacy hook cleanup succeeds with unrelated content and reports edit failures.
+
+set -u
+
+REPO_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+TMP_DIR="${TMPDIR:-/tmp}/agh-installer-legacy-hook-cleanup.$$"
+FUNCTIONS_FILE="${TMP_DIR}/functions.sh"
+
+cleanup() {
+	rm -rf "${TMP_DIR}"
+}
+
+fail() {
+	printf '%s\n' "FAIL: $*" >&2
+	exit 1
+}
+
+trap cleanup 0
+trap 'cleanup; exit 1' HUP INT TERM
+
+mkdir -p "${TMP_DIR}" || exit 1
+awk '
+	/^_quote\(\)/,/^}/
+	/^PTXT\(\)/,/^}/
+	/^del_jffs_script\(\)/,/^}/
+' "${REPO_DIR}/installer" >"${FUNCTIONS_FILE}"
+
+(
+	# shellcheck disable=SC1090
+	. "${FUNCTIONS_FILE}"
+	ADDON_DIR="/opt/etc/AdGuardHome"
+	TARGET="${TMP_DIR}/mixed-script"
+	cat >"${TARGET}" <<'EOF'
+#!/bin/sh
+
+[ -x /opt/etc/AdGuardHome/AdGuardHome.sh ] && /opt/etc/AdGuardHome/AdGuardHome.sh legacy
+echo unrelated
+EOF
+
+	del_jffs_script "${TARGET}" !manager ||
+		fail "successful legacy hook cleanup returned failure"
+	grep -q '^echo unrelated$' "${TARGET}" ||
+		fail "unrelated script content was removed"
+	if grep -q 'AdGuardHome.sh' "${TARGET}"; then
+		fail "legacy hook was not removed"
+	fi
+) || exit 1
+
+(
+	# shellcheck disable=SC1090
+	. "${FUNCTIONS_FILE}"
+	ADDON_DIR="/opt/etc/AdGuardHome"
+	TARGET="${TMP_DIR}/failed-edit"
+	printf '%s\n' '#!/bin/sh' '[ -x /opt/etc/AdGuardHome/old ] && old' >"${TARGET}"
+	sed() {
+		case "$1" in
+			-i) return 1 ;;
+		esac
+		command sed "$@"
+	}
+	if del_jffs_script "${TARGET}"; then
+		fail "legacy hook cleanup ignored an edit failure"
+	fi
+) || exit 1
+
+printf '%s\n' 'OK: installer legacy hook cleanup regression'

--- a/tools/code-quality.sh
+++ b/tools/code-quality.sh
@@ -93,6 +93,7 @@ run_check 'Canonical path final-symlink regression' sh tests/canonical-path-syml
 run_check 'Router runtime PATH priority regression' sh tests/router-path-priority.sh
 run_check 'Static archive failure safety regression' sh tests/download-static-failure-safety.sh
 run_check 'Installer file failure safety regression' sh tests/installer-file-failure-safety.sh
+run_check 'Installer legacy hook cleanup regression' sh tests/installer-legacy-hook-cleanup.sh
 run_check 'Installer post-replacement restart regression' sh tests/installer-post-replace-restart.sh
 run_check 'Installer menu range regression' sh tests/installer-menu-range.sh
 run_check 'Installer iterative input regression' sh tests/installer-input-loops.sh


### PR DESCRIPTION
### Motivation
- Prevent `del_jffs_script` from returning failure when it successfully removes an old AdGuardHome hook but other unrelated commands remain in the JFFS event script, which caused `write_manager_script` to abort and leave event scripts unconfigured.

### Description
- Make `del_jffs_script` explicitly return success after removing matching legacy hook lines while still propagating actual sort/read/sed/rm failures, and tighten its edit checks to surface edit errors early.  
- Replace the previous `while`-read pipeline with an explicit sorted iteration to avoid subshell return-status masking and add explicit `sed`/`awk` error handling.  
- Remove files that become only a shebang after cleanup and ensure the function returns `0` on successful cleanup.  
- Add `tests/installer-legacy-hook-cleanup.sh` to verify mixed-content cleanup and the propagation of edit failures, register that test in `tools/code-quality.sh`, and refresh `installer.md5sum`.

### Testing
- Ran `sh tests/installer-legacy-hook-cleanup.sh`, which passed.  
- Performed a syntax check with `sh -n installer tests/installer-legacy-hook-cleanup.sh tools/code-quality.sh`, which passed.  
- Verified artifact checks with `sh tools/check-md5.sh`, which passed.  
- Executed `tools/code-quality.sh`, which ran all repository regression checks and reported all available regressions passed; the overall script returned nonzero only because `shellcheck` and `shfmt` are not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2db9d85f04832982eadf58737d088d)