### PR TITLE
Clear archive publication state before deleting rollback copies

### DIFF
--- a/tests/download-static-failure-safety.sh
+++ b/tests/download-static-failure-safety.sh
@@ -70,6 +70,33 @@ fi
 	fail "archive publication removed the previous archive before replacement"
 
 unset -f mv
+REAL_RM="$(which rm)" || fail "rm is unavailable"
+printf '%s\n' "old archive" >"${TEST_ROOT}/archive"
+printf '%s\n' "old checksum" >"${TEST_ROOT}/archive.md5sum"
+printf '%s\n' "new archive" >"${TEST_ROOT}/archive.tmp"
+rm() {
+	case "$*" in
+		*archive.publish-in-progress*) return 1 ;;
+	esac
+	"${REAL_RM}" "$@"
+}
+if publish_archive_with_md5 "${TEST_ROOT}/archive.tmp" "${TEST_ROOT}/archive" newchecksum >/dev/null 2>&1; then
+	fail "archive publication accepted a publication-state cleanup failure"
+fi
+[ "$(sed -n '1p' "${TEST_ROOT}/archive")" = "new archive" ] ||
+	fail "state cleanup failure replaced the newly published archive"
+[ "$(sed -n '1p' "${TEST_ROOT}/archive.md5sum")" = "newchecksum" ] ||
+	fail "state cleanup failure replaced the newly published checksum"
+[ -e "${TEST_ROOT}/archive.previous" ] ||
+	fail "state cleanup failure discarded the archive rollback copy"
+[ -e "${TEST_ROOT}/archive.md5sum.previous" ] ||
+	fail "state cleanup failure discarded the checksum rollback copy"
+[ -e "${TEST_ROOT}/archive.publish-in-progress" ] ||
+	fail "failed publication state cleanup unexpectedly removed the state marker"
+unset -f rm
+"${REAL_RM}" -f "${TEST_ROOT}/archive.publish-in-progress" \
+	"${TEST_ROOT}/archive.previous" "${TEST_ROOT}/archive.md5sum.previous"
+
 PUBLISH_START_TIME="$(awk '{
 	sub(/^.*\) /, "")
 	print $20

--- a/tools/download-adguardhome-static.sh
+++ b/tools/download-adguardhome-static.sh
@@ -279,7 +279,12 @@ publish_archive_with_md5() {
 
 	if mv "${_archive_tmp}" "${_archive_file}" &&
 		mv "${_md5_tmp}" "${_md5_file}"; then
-		rm -f "${_archive_backup}" "${_md5_backup}" "${_publish_state}"
+		if ! rm -f "${_publish_state}"; then
+			printf '%s\n' "Error: could not clear publication state for ${_archive_file}" >&2
+			FAILED=1
+			return 1
+		fi
+		rm -f "${_archive_backup}" "${_md5_backup}"
 		return 0
 	fi
 


### PR DESCRIPTION
### Motivation
- Ensure the publication-state marker is cleared and verified before discarding rollback copies so a failure to remove the marker does not leave the canonical archive/checksum published without rollback copies.

### Description
- Modify `publish_archive_with_md5` in `tools/download-adguardhome-static.sh` to remove and verify the `.publish-in-progress` marker before deleting `.previous` rollback files and to treat inability to clear the marker as a publication error that preserves backups.
- Extend `tests/download-static-failure-safety.sh` with a simulated `rm` failure to validate that a publication-state cleanup failure leaves the new canonical files, the transaction marker, and rollback copies intact.

### Testing
- Ran a syntax check and the focused unit test: `sh -n tools/download-adguardhome-static.sh tests/download-static-failure-safety.sh` and `sh tests/download-static-failure-safety.sh`, both of which passed for the new behavior.
- Executed `tools/code-quality.sh`; the targeted static-publication regression passed but the suite returned nonzero due to an unrelated router PATH regression and because `shellcheck`/`shfmt` are not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dcc4301bc832993176557bc957086)