### PR TITLE
Align router PATH regression expectations with runtime exports

### DIFF
--- a/tests/router-path-priority.sh
+++ b/tests/router-path-priority.sh
@@ -12,10 +12,7 @@ for script in AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome; do
 	[ -f "${script}" ] || fail "missing runtime script: ${script}"
 
 	path_statement="$(sed -n '/^export PATH=/p' "${script}" | sed -n '1p')"
-	expected_path='export PATH="/sbin:/bin:/usr/sbin:/usr/bin:${PATH:-}"'
-	if [ "${script}" = "S99AdGuardHome" ]; then
-		expected_path='export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/opt/sbin:/opt/bin:${PATH:-}"'
-	fi
+	expected_path='export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/opt/sbin:/opt/bin:/opt/usr/sbin:/opt/usr/bin:${PATH:-}"'
 	[ "${path_statement}" = "${expected_path}" ] ||
 		fail "${script} does not prepend stock paths while preserving the caller PATH"
 
@@ -31,10 +28,12 @@ ${expected_path}"
 		fail "${script} executes code before setting its locale and PATH"
 done
 
-case "$(sed -n '/^export PATH=/p' S99AdGuardHome | sed -n '1p')" in
-	*:/opt/sbin:/opt/bin:*) ;;
-	*) fail "S99AdGuardHome does not include the Entware binary directories" ;;
-esac
+for script in AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome; do
+	case "$(sed -n '/^export PATH=/p' "${script}" | sed -n '1p')" in
+		*:/opt/sbin:/opt/bin:/opt/usr/sbin:/opt/usr/bin:*) ;;
+		*) fail "${script} does not include the Entware binary directories" ;;
+	esac
+done
 
 PATH="/feedback-test-path"
 export PATH="/sbin:/bin:/usr/sbin:/usr/bin:${PATH:-}"


### PR DESCRIPTION
### Motivation
- The runtime scripts were updated to export an expanded PATH that includes both `/opt/sbin:/opt/bin` and `/opt/usr/sbin:/opt/usr/bin`, so the PATH-priority regression test needed to be aligned with the actual exported strings.

### Description
- Update `tests/router-path-priority.sh` to expect the full exported PATH in `AdGuardHome.sh`, `S99AdGuardHome`, and `rc.func.AdGuardHome`, and to assert Entware directories are present for each script.

### Testing
- Ran `sh tests/router-path-priority.sh`, `sh -n tests/router-path-priority.sh`, and `git diff --check`, and verified the working tree is clean after committing the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dce7185708329be0bdab3da73b8a8)