### PR TITLE
Write generated credentials into the staged AdGuardHome YAML

### DIFF
--- a/installer
+++ b/installer
@@ -432,6 +432,8 @@ sanitize_branch() {
 # AdGuardHome process helpers
 
 AdGuardHome_authen() {
+	local AUTH_YAML
+	AUTH_YAML="${2:-${YAML_ORI}}"
 	if [ -z "${PW1}" ] || [ -z "${PW2}" ]; then
 		local USERNAME
 		PTXT -n "${INPUT} Please enter AdGuardHome username${NORM}: "
@@ -446,7 +448,7 @@ AdGuardHome_authen() {
 	PTXT " "
 	if [ -z "${PW1}" ] || [ -z "${PW2}" ] || [ "${PW1}" != "${PW2}" ]; then
 		PTXT "${ERROR} Password entered incorrectly!"
-		AdGuardHome_authen "$1"
+		AdGuardHome_authen "$1" "${AUTH_YAML}"
 		return
 	fi
 	remove_conflicting_apache
@@ -486,7 +488,7 @@ AdGuardHome_authen() {
 	else
 		PTXT "users:" \
 			"- name: ${USERNAME}" \
-			"  password: ${PW1_ENCRYPTED}" >>"${YAML_ORI}"
+			"  password: ${PW1_ENCRYPTED}" >>"${AUTH_YAML}"
 	fi
 }
 
@@ -2055,7 +2057,7 @@ setup_AdGuardHome_impl() {
 					PTXT "http:" \
 						"  address: 0.0.0.0:${WEB_PORT}" >"${YAML_ORI_NEW}"
 					PTXT "${INFO} Set the Username and Password which will be encrypted to the yaml file."
-					AdGuardHome_authen 1
+					AdGuardHome_authen 1 "${YAML_ORI_NEW}"
 					PTXT "dns:" \
 						"  bind_hosts:" \
 						"    - 0.0.0.0" \

--- a/installer.md5sum
+++ b/installer.md5sum
@@ -1,1 +1,1 @@
-07a261816f5063c31beb8c03bbef3a36  installer
+4f4f7d0358bf0defff9f6b5be5dcc3d2  installer

--- a/tests/installer-staged-authentication.sh
+++ b/tests/installer-staged-authentication.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Verify generated credentials are written to the staged YAML snapshot.
+
+set -u
+
+SCRIPT_PATH="${1:-installer}"
+
+fail() {
+	printf '%s\n' "FAIL: $*" >&2
+	exit 1
+}
+
+[ -f "${SCRIPT_PATH}" ] || fail "installer script not found: ${SCRIPT_PATH}"
+
+INPUT='Input:'
+NORM=''
+ERROR='Error:'
+AUTH_FUNCTION="$(sed -n '/^AdGuardHome_authen() {$/,/^agh_check() {$/p' "${SCRIPT_PATH}" | sed '$d')"
+[ -n "${AUTH_FUNCTION}" ] || fail 'could not extract authentication function'
+eval "${AUTH_FUNCTION}"
+
+TMP_ROOT="${TMPDIR:-/tmp}/installer-staged-authentication.$$"
+YAML_ORI="${TMP_ROOT}/original.yaml"
+YAML_STAGED="${TMP_ROOT}/staged.yaml"
+PW1='secret'
+PW2='secret'
+USERNAME='admin'
+
+cleanup() {
+	rm -rf "${TMP_ROOT}"
+}
+trap cleanup 0
+trap 'cleanup; exit 1' HUP INT TERM
+
+mkdir -p "${TMP_ROOT}" || fail 'could not create test directory'
+printf '%s\n' 'original snapshot' >"${YAML_ORI}"
+printf '%s\n' 'http:' >"${YAML_STAGED}"
+
+PTXT() {
+	printf '%s\n' "$@"
+}
+remove_conflicting_apache() { :; }
+ensure_password_hash_tool() { return 0; }
+python_bcrypt_available() { return 0; }
+hash_password_python() {
+	printf '%s\n' '$2a$10$012345678901234567890123456789012345678901234567890123'
+}
+
+AdGuardHome_authen 1 "${YAML_STAGED}" <<'EOF'
+secret
+secret
+EOF
+
+[ "$(cat "${YAML_ORI}")" = 'original snapshot' ] || fail 'authentication modified the published original snapshot'
+grep -q '^users:$' "${YAML_STAGED}" || fail 'staged YAML is missing the users section'
+grep -q '^- name: admin$' "${YAML_STAGED}" || fail 'staged YAML is missing the selected username'
+grep -q '^  password: \$2a\$10\$' "${YAML_STAGED}" || fail 'staged YAML is missing the generated password hash'
+
+printf '%s\n' 'PASS: generated credentials are written to the staged YAML snapshot'

--- a/tools/code-quality.sh
+++ b/tools/code-quality.sh
@@ -112,6 +112,7 @@ run_check 'Installer legacy hook cleanup regression' sh tests/installer-legacy-h
 run_check 'Installer post-replacement restart regression' sh tests/installer-post-replace-restart.sh
 run_check 'Installer menu range regression' sh tests/installer-menu-range.sh
 run_check 'Installer iterative input regression' sh tests/installer-input-loops.sh
+run_check 'Installer staged authentication regression' bash tests/installer-staged-authentication.sh
 run_check 'Installer mandatory numeric input failure regression' sh tests/installer-mandatory-number-failure.sh
 run_check 'Installer DNS input failure regression' sh tests/installer-dns-input-failure.sh
 run_check 'Installer WebUI port failure regression' sh tests/installer-web-port-failure.sh


### PR DESCRIPTION
### Motivation
- Prevent the installer from writing generated WebUI credentials into the published original snapshot instead of the staged configuration during fresh setup or reconfiguration.  
- Ensure the staged YAML that is validated and later published contains the selected username and hashed password so the WebUI is not left without authentication after install.

### Description
- Extended `AdGuardHome_authen` to accept an explicit YAML destination parameter while preserving the existing default behavior.  
- Pass the staged path (`YAML_ORI_NEW`) to `AdGuardHome_authen` during fresh setup / option-3 reconfiguration so generated `users` and the encrypted `password` are appended to the staged file.  
- Added a regression test `tests/installer-staged-authentication.sh` that verifies the staged YAML receives the `users` entry and hashed password while the original snapshot remains unchanged, and registered the test in `tools/code-quality.sh`.  
- Updated the installer checksum sidecar to reflect the changes.

### Testing
- Ran `bash -n tests/installer-staged-authentication.sh` and `bash tests/installer-staged-authentication.sh`, which passed.  
- Executed `sh -n installer tools/code-quality.sh` and `sh tests/installer-dns-input-failure.sh`, which passed in this environment.  
- Verified `sh tools/check-md5.sh` succeeded and `git diff --check` reported no issues.  
- The new staged-authentication regression is included in the repository quality suite and was exercised by the above runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e1cf7cf9083299d7d038009181a0b)