### PR TITLE
Restore previous AdGuardHome binary when replacement is interrupted

### DIFF
--- a/installer
+++ b/installer
@@ -1311,16 +1311,27 @@ adguard_restart_after_install_abort() {
 
 adguard_install_abort_trap_disable() {
 	trap - HUP INT QUIT ABRT TERM
+	ADGUARD_INSTALL_REPLACE_ACTIVE="0"
+	ADGUARD_INSTALL_OLD_BINARY=""
 }
 
 adguard_install_abort_on_signal() {
+	local OLD_BINARY REPLACE_ACTIVE
+	OLD_BINARY="${ADGUARD_INSTALL_OLD_BINARY:-}"
+	REPLACE_ACTIVE="${ADGUARD_INSTALL_REPLACE_ACTIVE:-0}"
 	adguard_install_abort_trap_disable
-	adguard_restart_after_install_abort 1
+	if [ "${REPLACE_ACTIVE}" = "1" ] && [ -n "${OLD_BINARY}" ]; then
+		adguard_restore_after_failed_replace "${OLD_BINARY}" 1
+	else
+		adguard_restart_after_install_abort 1
+	fi
 	clear_screen
 	end_op_message 2
 }
 
 adguard_install_abort_trap_enable() {
+	ADGUARD_INSTALL_REPLACE_ACTIVE="0"
+	ADGUARD_INSTALL_OLD_BINARY=""
 	trap 'adguard_install_abort_on_signal' HUP INT QUIT ABRT TERM
 }
 
@@ -1408,6 +1419,8 @@ install_adguard_archive() {
 		adguard_restart_after_failed_replace "${WAS_RUNNING}"
 		return 1
 	fi
+	ADGUARD_INSTALL_OLD_BINARY="${OLD_BINARY}"
+	ADGUARD_INSTALL_REPLACE_ACTIVE="1"
 	if ! mv "${STAGE_BINARY}" "${AGH_FILE}"; then
 		adguard_install_abort_trap_disable
 		rm -rf "${STAGE_DIR}"
@@ -1426,6 +1439,8 @@ install_adguard_archive() {
 		return 1
 	fi
 	rm -f "${OLD_BINARY}"
+	ADGUARD_INSTALL_REPLACE_ACTIVE="0"
+	ADGUARD_INSTALL_OLD_BINARY=""
 	rm -rf "${STAGE_DIR}"
 	return 0
 }

--- a/installer.md5sum
+++ b/installer.md5sum
@@ -1,1 +1,1 @@
-17a490cfde25e189f77f9629735d0e8f  installer
+5fb7547b98b6c29b0bc99009592de648  installer

--- a/tests/installer-interruption-restart.sh
+++ b/tests/installer-interruption-restart.sh
@@ -37,6 +37,9 @@ sed -n \
 	adguard_restart_after_install_abort() {
 		printf '%s\n' "restart:$1" >>"${CALLS_FILE}"
 	}
+	adguard_restore_after_failed_replace() {
+		printf '%s\n' "restore:$1:$2" >>"${CALLS_FILE}"
+	}
 	clear_screen() {
 		printf '%s\n' 'clear' >>"${CALLS_FILE}"
 	}
@@ -53,12 +56,42 @@ ACTUAL="$(cat "${CALLS_FILE}")"
 [ "${ACTUAL}" = "${EXPECTED}" ] ||
 	fail "interruption recovery did not restart before the aborted-operation flow: ${ACTUAL}"
 
+(
+	# shellcheck disable=SC1090
+	. "${FUNCTIONS_FILE}"
+
+	adguard_restart_after_install_abort() {
+		printf '%s\n' "unexpected-restart:$1" >>"${CALLS_FILE}"
+	}
+	adguard_restore_after_failed_replace() {
+		printf '%s\n' "restore:$1:$2" >>"${CALLS_FILE}"
+	}
+	clear_screen() {
+		printf '%s\n' 'clear' >>"${CALLS_FILE}"
+	}
+	end_op_message() {
+		printf '%s\n' "end:$1" >>"${CALLS_FILE}"
+	}
+
+	adguard_install_abort_trap_enable
+	ADGUARD_INSTALL_OLD_BINARY="${TMP_ROOT}/previous"
+	ADGUARD_INSTALL_REPLACE_ACTIVE="1"
+	adguard_install_abort_on_signal
+) || fail 'interrupted replacement recovery handler failed'
+
+EXPECTED="$(printf '%s\n' 'restart:1' 'clear' 'end:2' "restore:${TMP_ROOT}/previous:1" 'clear' 'end:2')"
+ACTUAL="$(cat "${CALLS_FILE}")"
+[ "${ACTUAL}" = "${EXPECTED}" ] ||
+	fail "interruption recovery did not restore the previous binary: ${ACTUAL}"
+
 awk '
 	/^install_adguard_archive\(\) \{/ { in_function = 1 }
 	in_function && /adguard_install_abort_trap_enable/ { enable = NR }
 	in_function && /agh_prepare_binary_replace/ { prepare = NR }
+	in_function && /ADGUARD_INSTALL_REPLACE_ACTIVE="1"/ { replace = NR }
+	in_function && /mv "\$\{STAGE_BINARY\}" "\$\{AGH_FILE\}"/ { publish = NR }
 	in_function && /^}/ { exit }
-	END { exit !(enable && prepare && enable < prepare) }
-' "${SCRIPT_PATH}" || fail 'interruption trap is not enabled before binary replacement'
+	END { exit !(enable && prepare && enable < prepare && replace && publish && replace < publish) }
+' "${SCRIPT_PATH}" || fail 'interruption rollback state is not enabled before binary publication'
 
 printf '%s\n' 'PASS: installation interruption restarts the previously running service'


### PR DESCRIPTION
### Motivation
- Prevent leaving an unvalidated or unusable AdGuardHome binary installed or running if the installer is interrupted during binary replacement. 
- Ensure signal handlers restore a preserved rollback copy when replacement is active instead of only attempting a restart.

### Description
- Added transient replacement state with `ADGUARD_INSTALL_REPLACE_ACTIVE` and `ADGUARD_INSTALL_OLD_BINARY` and wired them into the install signal handlers so interruptions during replacement restore the preserved binary instead of restarting a potentially invalid new one. 
- Updated `adguard_install_abort_trap_enable`/`adguard_install_abort_trap_disable` and `adguard_install_abort_on_signal` to consult the replacement state and call `adguard_restore_after_failed_replace` when appropriate. 
- Marked replacement active before moving the staged binary into place and clear the marker only after ownership/permission/version validation succeeds. 
- Extended the interruption regression `tests/installer-interruption-restart.sh` to assert both restart-only and restore-on-interrupt behaviors and refreshed the `installer.md5sum` sidecar.

### Testing
- Ran `tools/code-quality.sh`, which executed the repository test suite and the new interruption test; all available regression checks passed, with the job exit nonzero only because `shellcheck` and `shfmt` are not installed in the environment. 
- Executed the focused tests `sh tests/installer-interruption-restart.sh`, `sh tests/installer-file-failure-safety.sh`, and `sh tests/installer-post-replace-restart.sh`, which passed locally. 
- Verified `sh tools/check-md5.sh` and `sh -n installer tests/installer-interruption-restart.sh tools/code-quality.sh` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ee64273d083299aa9e1fc793b1326)