### PR TITLE
Preserve deferred cleanup during restore setup

### DIFF
--- a/installer
+++ b/installer
@@ -1357,7 +1357,6 @@ adguard_restart_after_install_abort() {
 
 adguard_install_abort_trap_disable() {
 	trap - HUP INT QUIT ABRT TERM
-	ADGUARD_DEFER_END_OP="0"
 	ADGUARD_INSTALL_REPLACE_ACTIVE="0"
 	ADGUARD_INSTALL_OLD_BINARY=""
 	ADGUARD_INSTALL_STAGE_DIR=""

--- a/tests/installer-file-failure-safety.sh
+++ b/tests/installer-file-failure-safety.sh
@@ -585,6 +585,10 @@ EOF
 		if [ "${ADGUARD_DEFER_END_OP:-0}" != "1" ]; then
 			fail "final restore setup was not run with deferred end_op_message"
 		fi
+		adguard_install_abort_trap_disable
+		if [ "${ADGUARD_DEFER_END_OP:-0}" != "1" ]; then
+			fail "trap disable cleared deferred end_op_message before restore cleanup"
+		fi
 		end_op_message 0 "$1"
 	}
 


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where `adguard_install_abort_trap_disable` cleared `ADGUARD_DEFER_END_OP`, causing `end_op_message` to run early and leaving the old install in the rollback directory instead of allowing the outer restore cleanup/rollback path to run.

### Description
- Remove the `ADGUARD_DEFER_END_OP="0"` assignment from `adguard_install_abort_trap_disable` in `installer` and update the failure-safety test `tests/installer-file-failure-safety.sh` to simulate a nested `inst_AdGuardHome` that calls `adguard_install_abort_trap_disable` and assert the deferred flag remains set.

### Testing
- Performed syntax checks with `sh -n installer` and `sh -n tests/installer-file-failure-safety.sh` and executed `sh tests/installer-file-failure-safety.sh`; the test script completed successfully and reported `PASS`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3349cd6d4c8329bf216cb0465ee9ca)