### PR TITLE
Fix stale dnsmasq handoff startup recovery

### DIFF
--- a/rc.func.AdGuardHome
+++ b/rc.func.AdGuardHome
@@ -113,6 +113,20 @@ reload() {
 	signal_process "${SIGNAL}" "${PROC}"
 }
 
+adguardhome_start_handoff_is_prepared() {
+	_dns_handoff_pid=""
+	_dns_handoff_start_time=""
+	[ "${PROC}" = "AdGuardHome" ] || return 1
+	type dns_handoff_marker_is_active >/dev/null 2>&1 || return 1
+	type dns_handoff_set_current_identity >/dev/null 2>&1 || return 1
+	dns_handoff_set_current_identity || return 1
+	dns_handoff_marker_is_active || return 1
+	IFS=' ' read -r _dns_handoff_pid _dns_handoff_start_time <"${DNS_HANDOFF_FILE}" ||
+		return 1
+	[ "${_dns_handoff_pid}" = "${DNS_HANDOFF_CURRENT_PID}" ] &&
+		[ "${_dns_handoff_start_time}" = "${DNS_HANDOFF_CURRENT_START_TIME}" ]
+}
+
 start() {
 	local DNS_HANDOFF LAUNCH_PID PIDS STOPPED
 	{ [ "${CRITICAL}" != "yes" ] && [ "${CALLER}" = "cron" ]; } && return 7
@@ -124,11 +138,11 @@ start() {
 		printf "%s\n" "            ${ansi_yellow} already running. ${ansi_std}"
 		return 0
 	fi
-	if [ "${PROC}" != "AdGuardHome" ] || ! grep -q '^port=553' /etc/dnsmasq.conf; then
-		if [ "${PROC}" = "AdGuardHome" ]; then
-			DNS_HANDOFF=1
-			trap 'stop_launched_process "${LAUNCH_PID:-}"; [ -n "${POSTFAILCMD:-}" ] && ${POSTFAILCMD} >/dev/null 2>&1; exit 255' HUP INT TERM
-		fi
+	if [ "${PROC}" = "AdGuardHome" ]; then
+		DNS_HANDOFF=1
+		trap 'stop_launched_process "${LAUNCH_PID:-}"; [ -n "${POSTFAILCMD:-}" ] && ${POSTFAILCMD} >/dev/null 2>&1; exit 255' HUP INT TERM
+	fi
+	if ! adguardhome_start_handoff_is_prepared; then
 		if ! ${PRECMD} >/dev/null 2>&1; then
 			printf "%s\n" "            ${ansi_red} failed. ${ansi_std}"
 			logger -st "${CALLER}" "Pre-start hook failed for ${DESC} from ${CALLER}."

--- a/rc.func.AdGuardHome.md5sum
+++ b/rc.func.AdGuardHome.md5sum
@@ -1,1 +1,1 @@
-2d936102797d61c4ee5ba2fa1504a5c7  rc.func.AdGuardHome
+4cd87d120cfb8070f8ab7747c7b95433

--- a/tests/dns-startup-handoff.sh
+++ b/tests/dns-startup-handoff.sh
@@ -30,7 +30,7 @@ sed -n \
 	"${S99_PATH}" >"${S99_FUNCTIONS}" || fail "could not read ${S99_PATH}"
 sed -n '/^dns_handoff_is_active() {$/,/^}$/p' "${MANAGER_PATH}" >>"${S99_FUNCTIONS}" ||
 	fail "could not read ${MANAGER_PATH}"
-sed -n '/^stop_launched_process() {$/,/^}$/p; /^start() {$/,/^}$/p' "${RC_PATH}" >"${RC_FUNCTION}" ||
+sed -n '/^stop_launched_process() {$/,/^}$/p; /^adguardhome_start_handoff_is_prepared() {$/,/^}$/p; /^start() {$/,/^}$/p' "${RC_PATH}" >"${RC_FUNCTION}" ||
 	fail "could not read ${RC_PATH}"
 [ -s "${S99_FUNCTIONS}" ] || fail 'DNS handoff functions were not found'
 [ -s "${RC_FUNCTION}" ] || fail 'service start function was not found'
@@ -521,6 +521,29 @@ rm -f "${STARTED_FILE}"
 ) || fail 'rc.func failed a successful handoff start'
 grep -q '^pre_hook$' "${CALLS_FILE}" || fail 'rc.func did not run the pre-start handoff hook'
 grep -q '^post_hook$' "${CALLS_FILE}" || fail 'rc.func skipped post-start cleanup after dnsmasq changed to port 553'
+
+# A stale dnsmasq port 553 config without an active marker must be recovered by
+# running the pre-start hook again.  The old skip was keyed only to the config
+# content and would bypass the hook in this state.
+: >"${CALLS_FILE}"
+rm -f "${STARTED_FILE}" "${DNS_HANDOFF_FILE}"
+(
+	grep() {
+		case "$*" in
+			*'/etc/dnsmasq.conf'*) return 0 ;;
+			*) command grep "$@" ;;
+		esac
+	}
+	pre_hook() {
+		printf '%s\n' stale_pre_hook >>"${CALLS_FILE}"
+	}
+	post_hook() {
+		printf '%s\n' stale_post_hook >>"${CALLS_FILE}"
+	}
+	start >/dev/null
+) || fail 'rc.func failed to recover a stale dnsmasq port 553 startup'
+grep -q '^stale_pre_hook$' "${CALLS_FILE}" || fail 'rc.func skipped pre-start with stale dnsmasq port 553 and no active handoff marker'
+grep -q '^stale_post_hook$' "${CALLS_FILE}" || fail 'rc.func skipped post-start cleanup after stale dnsmasq port 553 recovery'
 
 # Interrupting startup after the pre-start hook has spawned the DNS guard must
 # reap that child and run the same dnsmasq recovery used by other failed starts.


### PR DESCRIPTION
### Motivation

- Ensure AdGuardHome always runs its guarded pre-start recovery when starting unless an exact, active dnsmasq handoff marker proves the current startup already performed the handoff, so stale `port=553` configs don't bypass recovery.

### Description

- Add a POSIX-safe helper `adguardhome_start_handoff_is_prepared()` that verifies the dnsmasq handoff marker belongs to the current process by checking PID and start time via existing handoff helpers.
- Change `start()` so `AdGuardHome` startups enter the guarded path and run `${PRECMD}` unless `adguardhome_start_handoff_is_prepared()` returns success, replacing the previous skip keyed only to `/etc/dnsmasq.conf` containing `port=553`.
- Update the test harness extraction to include the new helper when loading `start()` from `rc.func.AdGuardHome`.
- Add a regression test case to `tests/dns-startup-handoff.sh` that seeds a `port=553` dnsmasq config without a valid handoff marker and asserts the pre-start hook runs and post-start cleanup executes.

### Testing

- Ran `sh -n rc.func.AdGuardHome S99AdGuardHome` to validate shell syntax, which succeeded.
- Ran the full dns startup handoff tests with `sh tests/dns-startup-handoff.sh`, which printed `DNS startup handoff tests passed.` and therefore succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34cabc2318832998260276e9d5879c)