### PR TITLE
Use PTXT for installer retry failure output

### DIFF
--- a/installer
+++ b/installer
@@ -1429,7 +1429,7 @@ check_version() {
 				varcnt="$((varcnt + 1))"
 				if [ "${varcnt}" -ge 2 ]; then
 					rm -f "${REMOTE_INSTALLER}" "${REMOTE_INSTALLER_MD5}"
-					printf "%s\n" "One or more critical variables could not be set in a timely manner." "Please check your internet connection, or try again later." "The installer script will now exit."
+					PTXT "One or more critical variables could not be set in a timely manner." "Please check your internet connection, or try again later." "The installer script will now exit."
 					sleep 3s
 					exit 1
 				fi

--- a/installer.md5sum
+++ b/installer.md5sum
@@ -1,1 +1,1 @@
-27e305e05ae6cfa3ae12de27cffbb908
+fe54e64b7dbe9b94ff45d6ecb552e159


### PR DESCRIPTION
### Motivation
- Standardize console output by using the existing `PTXT` helper for human-facing messages in the checksum/version retry failure branch while preserving existing stdout/stderr behavior.

### Description
- Replaced the multi-line `printf "%s\n" ...` call in `installer` (retry failure branch) with a `PTXT` call using the same three message arguments.

### Testing
- Ran `sh -n installer` with no syntax errors reported. 
- `shellcheck -s sh installer` was not run because ShellCheck is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d75aebdac83298500cfcee699a0d8)