### PR TITLE
Document unused blocklist analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This project installs, updates, reconfigures, backs up, and removes AdGuardHome 
 - Supports updating AdGuardHome without reinstalling or reconfiguring from scratch.
 - Includes installer, update, backup, reconfiguration, and uninstall flows.
 - Provides service integration through Entware init scripts and Asuswrt-Merlin service events.
-- Can run an unused blocklist analyzer to identify filter lists that did not uniquely contribute blocks in the current AdGuardHome query log window.
+- Can run an unused blocklist analyzer from menu option **9** (or the `blocklists`/`unusedblocklists` actions) to identify filter lists with zero query-log rule hits in the analyzed window.
 
 ## Install, update, reconfigure, or uninstall
 
@@ -139,9 +139,9 @@ More DNS provider references:
 
 ## Unused blocklist analyzer
 
-The installer can download and run [`blocklilst_analyzer.py`](https://gist.github.com/graysky2/8035291d1bf87b8fe3693668965337e1), an AdGuard Home Blocklist Usage Analyzer script by [@graysky2](https://github.com/graysky2). The analyzer inspects AdGuardHome data under `${TARG_DIR}/data`, the filter cache under `${TARG_DIR}/data/filters`, and the AdGuardHome query log to report which filter lists contributed blocking rules during the analyzed log window.
+The analyzer is available from installer menu option **9**, or by running the installer with the `blocklists` or `unusedblocklists` action. The installer can download and run [`blocklilst_analyzer.py`](https://gist.github.com/graysky2/8035291d1bf87b8fe3693668965337e1), an AdGuard Home Blocklist Usage Analyzer script by [@graysky2](https://github.com/graysky2). The analyzer inspects AdGuardHome data under `${TARG_DIR}/data`, the filter cache under `${TARG_DIR}/data/filters`, and the AdGuardHome query log to report which filter lists had matching blocking-rule hits during the analyzed log window.
 
-In this report, **unused** means the blocklist did not uniquely contribute blocks in the query log entries that were analyzed. It does **not** mean the list is globally useless, redundant for every network, or safe to remove in all future traffic patterns. Review the printed list carefully before confirming any removal because removing filter lists can change blocking behavior.
+In this report, **unused** means the blocklist had zero `Result.Rules[].FilterListID` hits in the query log entries that were analyzed. It does **not** mean the list is globally useless, redundant for every network, or safe to remove in all future traffic patterns. Review the printed list carefully before confirming any removal because removing filter lists can change blocking behavior.
 
 When removal is confirmed, the installer backs up `${TARG_DIR}/AdGuardHome.yaml`, removes matching unused filter entries by `id:`, validates the resulting YAML with AdGuardHome's configuration checker, and restores the backup if validation fails. This restore path is intended to keep AdGuardHome from being left with an invalid configuration after an interrupted or failed cleanup.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This project installs, updates, reconfigures, backs up, and removes AdGuardHome 
 - [Service commands](#service-commands)
 - [Verify AdGuardHome is running](#verify-adguardhome-is-running)
 - [AdGuardHome DNS examples](#adguardhome-dns-examples)
+- [Unused blocklist analyzer](#unused-blocklist-analyzer)
 - [IPSET integration](#ipset-integration)
   - [Requirements and ownership](#requirements-and-ownership)
   - [Managed files and YAML](#managed-files-and-yaml)
@@ -60,6 +61,7 @@ This project installs, updates, reconfigures, backs up, and removes AdGuardHome 
 - Supports updating AdGuardHome without reinstalling or reconfiguring from scratch.
 - Includes installer, update, backup, reconfiguration, and uninstall flows.
 - Provides service integration through Entware init scripts and Asuswrt-Merlin service events.
+- Can run an unused blocklist analyzer to identify filter lists that did not uniquely contribute blocks in the current AdGuardHome query log window.
 
 ## Install, update, reconfigure, or uninstall
 
@@ -134,6 +136,22 @@ More DNS provider references:
 - [SNBForums AdGuardHome installer thread](http://www.snbforums.com/threads/release-asuswrt-merlin-adguardhome-installer-amaghi.76506/post-735471)
 - [AdGuard DNS providers knowledge base](https://adguard-dns.io/kb/general/dns-providers/)
 - [AdGuardHome wiki](https://github.com/AdguardTeam/AdGuardHome/wiki)
+
+## Unused blocklist analyzer
+
+The installer can download and run [`blocklilst_analyzer.py`](https://gist.github.com/graysky2/8035291d1bf87b8fe3693668965337e1), an AdGuard Home Blocklist Usage Analyzer script by [@graysky2](https://github.com/graysky2). The analyzer inspects AdGuardHome data under `${TARG_DIR}/data`, the filter cache under `${TARG_DIR}/data/filters`, and the AdGuardHome query log to report which filter lists contributed blocking rules during the analyzed log window.
+
+In this report, **unused** means the blocklist did not uniquely contribute blocks in the query log entries that were analyzed. It does **not** mean the list is globally useless, redundant for every network, or safe to remove in all future traffic patterns. Review the printed list carefully before confirming any removal because removing filter lists can change blocking behavior.
+
+When removal is confirmed, the installer backs up `${TARG_DIR}/AdGuardHome.yaml`, removes matching unused filter entries by `id:`, validates the resulting YAML with AdGuardHome's configuration checker, and restores the backup if validation fails. This restore path is intended to keep AdGuardHome from being left with an invalid configuration after an interrupted or failed cleanup.
+
+Python 3 is required to run the analyzer. On Entware-based installs, install it before using the analyzer if the installer has not already installed it for you:
+
+```sh
+opkg install python3
+```
+
+`python3` is an Entware dependency, not a stock Asuswrt-Merlin router command. The analyzer itself is optional; users who do not want Entware Python 3 installed can skip this feature and manage filter lists manually from the AdGuardHome web interface.
 
 ## IPSET integration
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This project installs, updates, reconfigures, backs up, and removes AdGuardHome 
 - Supports updating AdGuardHome without reinstalling or reconfiguring from scratch.
 - Includes installer, update, backup, reconfiguration, and uninstall flows.
 - Provides service integration through Entware init scripts and Asuswrt-Merlin service events.
-- Can run an unused blocklist analyzer from menu option **9** (or the `blocklists`/`unusedblocklists` actions) to identify filter lists with zero query-log rule hits in the analyzed window.
+- Can run an unused blocklist analyzer using menu option **9**, `sh installer blocklists`, or `sh installer unusedblocklists` to identify filter lists with zero query-log rule hits in the analyzed window.
 
 ## Install, update, reconfigure, or uninstall
 
@@ -139,7 +139,7 @@ More DNS provider references:
 
 ## Unused blocklist analyzer
 
-The analyzer is available from installer menu option **9**, or by running the installer with the `blocklists` or `unusedblocklists` action. The installer can download and run [`blocklilst_analyzer.py`](https://gist.github.com/graysky2/8035291d1bf87b8fe3693668965337e1), an AdGuard Home Blocklist Usage Analyzer script by [@graysky2](https://github.com/graysky2). The analyzer inspects AdGuardHome data under `${TARG_DIR}/data`, the filter cache under `${TARG_DIR}/data/filters`, and the AdGuardHome query log to report which filter lists had matching blocking-rule hits during the analyzed log window.
+Run the analyzer from installer menu option **9**, or call it directly with `sh installer blocklists` or `sh installer unusedblocklists`. The installer can download and run [`blocklilst_analyzer.py`](https://gist.github.com/graysky2/8035291d1bf87b8fe3693668965337e1), an AdGuard Home Blocklist Usage Analyzer script by [@graysky2](https://github.com/graysky2). The analyzer inspects AdGuardHome data under `${TARG_DIR}/data`, the filter cache under `${TARG_DIR}/data/filters`, and the AdGuardHome query log to report which filter lists had matching blocking-rule hits during the analyzed log window.
 
 In this report, **unused** means the blocklist had zero `Result.Rules[].FilterListID` hits in the query log entries that were analyzed. It does **not** mean the list is globally useless, redundant for every network, or safe to remove in all future traffic patterns. Review the printed list carefully before confirming any removal because removing filter lists can change blocking behavior.
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ In this report, **unused** means the blocklist did not uniquely contribute block
 
 When removal is confirmed, the installer backs up `${TARG_DIR}/AdGuardHome.yaml`, removes matching unused filter entries by `id:`, validates the resulting YAML with AdGuardHome's configuration checker, and restores the backup if validation fails. This restore path is intended to keep AdGuardHome from being left with an invalid configuration after an interrupted or failed cleanup.
 
+Removal can be handled in two ways after the unused list report is printed. The **ALL** option removes every listed unused filter in one pass after a single confirmation, which is faster but should be used only after reviewing the full printed list. The **one by one** option prompts for each unused filter individually so you can keep specific lists even if they were unused during the analyzed window. Both paths remove filters by their AdGuardHome `id:` entries and use the same backup, validation, and restore safety checks before the changed configuration is kept.
+
 Python 3 is required to run the analyzer. On Entware-based installs, install it before using the analyzer if the installer has not already installed it for you:
 
 ```sh


### PR DESCRIPTION
### Motivation

- Document the new unused blocklist analysis workflow so users understand what the installer does and its caveats. 
- Explain runtime requirements and Entware installation steps required to run the analyzer. 
- Warn users that removing lists can change blocking behavior and that the installer validates and restores YAML on failure.

### Description

- Add a Table of Contents entry for `Unused blocklist analyzer` and a Features bullet describing the analyzer capability. 
- Insert a new `## Unused blocklist analyzer` section linking to the `blocklilst_analyzer.py` gist by `@graysky2` and describing the analyzer behavior. 
- Document the analyzer inputs and scope: it inspects `${TARG_DIR}/data`, `${TARG_DIR}/data/filters`, and the AdGuardHome query log and reports lists that did not uniquely contribute blocks in the analyzed window. 
- Document removal safety: the installer backs up `${TARG_DIR}/AdGuardHome.yaml`, removes matching filter `id:` entries when confirmed, validates the YAML with AdGuardHome, and restores the backup if validation fails; also document the `python3` requirement and Entware install step `opkg install python3`.

### Testing

- Ran `git diff --check` to validate whitespace and diff issues, which completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d9e345c6c83299910b64d9602a35f)