### PR TITLE
Expand checksum tooling to include static AdGuardHome archives (armv5/armv7/armv8)

### DIFF
--- a/tools/check-md5.sh
+++ b/tools/check-md5.sh
@@ -85,7 +85,8 @@ validate_one() {
 }
 
 if [ "$#" -eq 0 ]; then
-	set -- installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome
+	set -- installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome \
+		armv5/*.tar.gz armv7/*.tar.gz armv8/*.tar.gz
 fi
 
 for target; do

--- a/tools/check-sha256.sh
+++ b/tools/check-sha256.sh
@@ -80,7 +80,8 @@ validate_one() {
 }
 
 if [ "$#" -eq 0 ]; then
-	set -- installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome
+	set -- installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome \
+		armv5/*.tar.gz armv7/*.tar.gz armv8/*.tar.gz
 fi
 
 for target; do

--- a/tools/update-checksums.sh
+++ b/tools/update-checksums.sh
@@ -89,7 +89,8 @@ update_one() {
 }
 
 if [ "$#" -eq 0 ]; then
-	set -- installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome
+	set -- installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome \
+		armv5/*.tar.gz armv7/*.tar.gz armv8/*.tar.gz
 fi
 
 for target; do

--- a/tools/update-md5.sh
+++ b/tools/update-md5.sh
@@ -81,7 +81,8 @@ update_one() {
 }
 
 if [ "$#" -eq 0 ]; then
-	set -- installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome
+	set -- installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome \
+		armv5/*.tar.gz armv7/*.tar.gz armv8/*.tar.gz
 fi
 
 for target; do


### PR DESCRIPTION
### Motivation

- Ensure generated and validated integrity metadata covers the static AdGuardHome release archives stored in `armv5/`, `armv7/`, and `armv8/` alongside existing installer/service artifacts. 
- Preserve existing MD5 sidecars for backwards compatibility while promoting SHA-256 as the preferred integrity metadata.

### Description

- Extend default targets in `tools/update-checksums.sh` so it generates both `.md5sum` and `.sha256sum` for `installer`, `AdGuardHome.sh`, `S99AdGuardHome`, `rc.func.AdGuardHome`, and `armv5/*.tar.gz`, `armv7/*.tar.gz`, `armv8/*.tar.gz` when no arguments are passed. 
- Extend default targets in `tools/check-sha256.sh`, `tools/check-md5.sh`, and `tools/update-md5.sh` to validate/update the same static archive set. 
- Kept MD5 tooling intact (compatibility metadata) and relied on existing installer logic which already prefers SHA-256, falls back to MD5, and emits a clear warning when only MD5 was usable. 
- Files changed: `tools/update-checksums.sh`, `tools/check-sha256.sh`, `tools/check-md5.sh`, and `tools/update-md5.sh`.

### Testing

- Ran `sh tools/update-checksums.sh` and observed no updates were needed (sidecars already current). ✅
- Performed syntax checks with `sh -n installer tools/check-md5.sh tools/check-sha256.sh tools/update-checksums.sh tools/update-md5.sh` which returned clean syntax. ✅
- Executed `sh tools/check-md5.sh` and `sh tools/check-sha256.sh` and confirmed all targeted `.md5sum` and `.sha256sum` sidecars match their artifacts. ✅
- Ran `tools/code-quality.sh` which passed repository regression checks but the helper failed at final formatting/lint dependency due to missing `shellcheck` and `shfmt` in the test environment. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45cbbb0ad083298bbe50fc414943ac)