### PR TITLE
Add `migrate-runtime-defaults` CLI helper, tests, and README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ sh installer ipset refresh --dry-run
 sh installer netcheck --mode wan --hosts "google.com github.com snbforums.com" --dns 127.0.0.1 --require-http NO --timeout 300
 sh installer dns-port-policy --policy refuse-unknown
 sh installer performance --profile balanced
+sh installer migrate-runtime-defaults
+sh installer migrate-runtime-defaults --dry-run
+sh installer migrate-runtime-defaults --yes
 sh installer uninstall --yes --allow-dns-nvram
 sh installer uninstall --dry-run
 ```
@@ -151,7 +154,9 @@ The dry-run paths print what would be done and avoid changing the live install.
 
 The `ipset refresh` command checks whether IPSET integration is enabled. Without `--yes`, it does not restart AdGuardHome; with `--yes`, it restarts AdGuardHome so refreshed mappings can take effect.
 
-The `netcheck`, `dns-port-policy`, and `performance` helpers only update installer configuration values. Restart AdGuardHome when you want the changed runtime behaviour to be loaded by the service scripts.
+The `migrate-runtime-defaults` helper inspects `/opt/etc/AdGuardHome/.config` (requires Entware and an installed AdGuardHome environment), reports legacy v2.6.0 runtime values, and only writes safer defaults when `--yes` is provided. Use `--dry-run` to report the same planned changes without writing them.
+
+The `netcheck`, `dns-port-policy`, `performance`, and `migrate-runtime-defaults` helpers only update installer configuration values. Restart AdGuardHome when you want the changed runtime behaviour to be loaded by the service scripts.
 
 ## Service commands
 
@@ -204,6 +209,21 @@ The `--fix` mode is intentionally limited. It can repair permissions, recreate t
 ## Runtime behavior settings
 
 v2.6.0 exposes several runtime behaviours through environment or `.config` settings. New installs save safer defaults; upgrades preserve existing `.config` values and pin legacy defaults when needed until users choose to migrate. Environment variables take precedence for the current invocation. Persistent settings can be placed in `/opt/etc/AdGuardHome/.config` (requires Entware and an installed AdGuardHome environment) using the same `NAME="value"` style already used by the installer.
+
+To inspect an upgraded install for legacy runtime defaults without changing `.config`, run:
+
+```sh
+sh installer migrate-runtime-defaults
+sh installer migrate-runtime-defaults --dry-run
+```
+
+To write the safer v2.6.0 defaults for legacy or missing runtime settings, run:
+
+```sh
+sh installer migrate-runtime-defaults --yes
+```
+
+The migration helper updates only legacy or missing runtime defaults. It preserves custom runtime choices such as `ADGUARD_NETCHECK_MODE="lan"`, `ADGUARD_PROC_OPTIMIZE="NO"`, or an already balanced/safe process profile.
 
 ### Netcheck modes
 

--- a/tests/installer-migrate-runtime-defaults.sh
+++ b/tests/installer-migrate-runtime-defaults.sh
@@ -21,7 +21,7 @@ trap 'cleanup; exit 1' HUP INT TERM
 mkdir -p "${TMP_ROOT}" || fail 'could not create test directory'
 
 sed -n \
-	'/^_quote() {$/,/^}$/p; /^PTXT() {$/,/^}$/p; /^ptxt_ok() {$/,/^}$/p; /^conf_value() {$/,/^}$/p; /^write_conf() {$/,/^}$/p; /^cli_write_quoted_conf() {$/,/^}$/p; /^cli_migrate_runtime_default() {$/,/^}$/p; /^cli_migrate_runtime_defaults() {$/,/^}$/p; /^cli_pre_runtime_defaults_preview() {$/,/^}$/p' \
+	'/^_quote() {$/,/^}$/p; /^PTXT() {$/,/^}$/p; /^ptxt_ok() {$/,/^}$/p; /^conf_value() {$/,/^}$/p; /^write_conf() {$/,/^}$/p; /^branch_is_safe() {$/,/^}$/p; /^cli_bool_value() {$/,/^}$/p; /^cli_adguard_branch_is_valid() {$/,/^}$/p; /^cli_simple_value_is_safe() {$/,/^}$/p; /^cli_host_list_is_safe() {$/,/^}$/p; /^cli_write_quoted_conf() {$/,/^}$/p; /^cli_netcheck_config_values() {$/,/^}$/p; /^cli_dns_port_policy() {$/,/^}$/p; /^cli_migrate_runtime_default() {$/,/^}$/p; /^cli_migrate_runtime_defaults() {$/,/^}$/p; /^cli_installer_branch_from_args() {$/,/^}$/p; /^cli_write_adguard_branch() {$/,/^}$/p; /^cli_run() {$/,/^}$/p; /^cli_pre_runtime_defaults_preview() {$/,/^}$/p' \
 	"${SCRIPT_PATH}" >"${FUNCTIONS_FILE}" || fail "could not read ${SCRIPT_PATH}"
 [ -s "${FUNCTIONS_FILE}" ] || fail 'runtime migration helper extraction was empty'
 grep -q '^cli_migrate_runtime_defaults() {$' "${FUNCTIONS_FILE}" || fail 'migration helper missing'
@@ -34,6 +34,18 @@ INFO='[i]'
 WARNING='[w]'
 ERROR='[!]'
 CONF_FILE="${TMP_ROOT}/.config"
+
+cli_require_yes() {
+	return 0
+}
+
+cli_enable_assume_yes() {
+	return 0
+}
+
+menu() {
+	fail "menu should not be called by migrate-runtime-defaults CLI"
+}
 
 cat >"${CONF_FILE}" <<'CONFIG'
 ADGUARDHOME_REFUSE_UNKNOWN_DNS_PORT_KILL="0"
@@ -64,7 +76,12 @@ if cli_pre_runtime_defaults_preview migrate-runtime-defaults --yes >/dev/null; t
 	fail 'preview short-circuit should not apply migrations before startup'
 fi
 
-cli_migrate_runtime_defaults --yes >"${TMP_ROOT}/apply" || fail 'apply migration failed'
+cli_run migrate-runtime-defaults --dry-run >"${TMP_ROOT}/cli-dry-run" || fail 'CLI dry-run migration failed'
+[ "$(cat "${CONF_FILE}")" = "${before}" ] || fail 'CLI dry-run migration changed .config'
+grep -q 'Dry-run: would write v2.6.0 safer runtime defaults' "${TMP_ROOT}/cli-dry-run" ||
+	fail 'CLI dry-run did not report planned writes'
+
+cli_run migrate-runtime-defaults --yes >"${TMP_ROOT}/apply" || fail 'CLI apply migration failed'
 grep -q '^ADGUARDHOME_REFUSE_UNKNOWN_DNS_PORT_KILL="1"$' "${CONF_FILE}" || fail 'DNS port policy was not migrated'
 grep -q '^ADGUARD_NETCHECK_MODE="wan"$' "${CONF_FILE}" || fail 'netcheck mode was not migrated'
 grep -q '^ADGUARD_PROC_OPTIMIZE="YES"$' "${CONF_FILE}" || fail 'process optimization was not preserved'

--- a/tests/runtime-default-regression.sh
+++ b/tests/runtime-default-regression.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Verify v2.6.0 runtime defaults and upgrade preservation paths.
+# Verify v2.6.0 runtime defaults, upgrade preservation, and migration paths.
 
 set -u
 
@@ -28,9 +28,10 @@ trap 'cleanup; exit 1' HUP INT TERM
 mkdir -p "${TMP_ROOT}" || fail 'could not create test directory'
 
 sed -n \
-	'/^_quote() {$/,/^}$/p; /^PTXT() {$/,/^}$/p; /^ptxt_ok() {$/,/^}$/p; /^conf_value() {$/,/^}$/p; /^conf_has_key() {$/,/^}$/p; /^write_conf_if_absent() {$/,/^}$/p; /^write_conf() {$/,/^}$/p; /^configure_runtime_defaults() {$/,/^}$/p' \
+	'/^_quote() {$/,/^}$/p; /^PTXT() {$/,/^}$/p; /^ptxt_ok() {$/,/^}$/p; /^conf_value() {$/,/^}$/p; /^conf_has_key() {$/,/^}$/p; /^write_conf_if_absent() {$/,/^}$/p; /^write_conf() {$/,/^}$/p; /^cli_write_quoted_conf() {$/,/^}$/p; /^configure_runtime_defaults() {$/,/^}$/p; /^cli_migrate_runtime_default() {$/,/^}$/p; /^cli_migrate_runtime_defaults() {$/,/^}$/p' \
 	"${INSTALLER_PATH}" >"${INSTALLER_FUNCTIONS}" || fail 'could not extract installer runtime helpers'
 grep -q '^configure_runtime_defaults() {$' "${INSTALLER_FUNCTIONS}" || fail 'configure_runtime_defaults helper missing'
+grep -q '^cli_migrate_runtime_defaults() {$' "${INSTALLER_FUNCTIONS}" || fail 'runtime migration helper missing'
 
 sed -n '/^dns_port_unknown_refusal_enabled() {$/,/^}$/p' "${S99_PATH}" >"${S99_FUNCTIONS}" ||
 	fail 'could not extract S99 DNS refusal helper'
@@ -76,6 +77,18 @@ grep -q '^ADGUARDHOME_REFUSE_UNKNOWN_DNS_PORT_KILL="0"$' "${CONF_FILE}" || fail 
 grep -q '^ADGUARD_NETCHECK_MODE="legacy"$' "${CONF_FILE}" || fail 'upgrade missing netcheck did not pin legacy mode'
 grep -q '^ADGUARD_PROC_OPTIMIZE="YES"$' "${CONF_FILE}" || fail 'upgrade missing optimize did not pin legacy enablement'
 grep -q '^ADGUARD_PROC_PROFILE="aggressive"$' "${CONF_FILE}" || fail 'upgrade missing profile did not pin aggressive compatibility'
+cli_migrate_runtime_defaults --dry-run >"${TMP_ROOT}/upgrade-missing-migrate-dry-run.out" ||
+	fail 'upgrade migration dry-run failed'
+grep -q '^ADGUARDHOME_REFUSE_UNKNOWN_DNS_PORT_KILL="0"$' "${CONF_FILE}" || fail 'upgrade migration dry-run rewrote legacy DNS cleanup'
+grep -q '^ADGUARD_NETCHECK_MODE="legacy"$' "${CONF_FILE}" || fail 'upgrade migration dry-run rewrote legacy netcheck mode'
+grep -q 'Dry-run: would write v2.6.0 safer runtime defaults' "${TMP_ROOT}/upgrade-missing-migrate-dry-run.out" ||
+	fail 'upgrade migration dry-run did not report planned safer defaults'
+cli_migrate_runtime_defaults --yes >"${TMP_ROOT}/upgrade-missing-migrate.out" ||
+	fail 'upgrade migration apply failed'
+grep -q '^ADGUARDHOME_REFUSE_UNKNOWN_DNS_PORT_KILL="1"$' "${CONF_FILE}" || fail 'upgrade migration did not enable DNS owner refusal'
+grep -q '^ADGUARD_NETCHECK_MODE="wan"$' "${CONF_FILE}" || fail 'upgrade migration did not save wan netcheck mode'
+grep -q '^ADGUARD_PROC_OPTIMIZE="YES"$' "${CONF_FILE}" || fail 'upgrade migration did not preserve optimization enablement'
+grep -q '^ADGUARD_PROC_PROFILE="balanced"$' "${CONF_FILE}" || fail 'upgrade migration did not save balanced profile'
 
 # shellcheck disable=SC1090
 . "${S99_FUNCTIONS}"
@@ -97,4 +110,4 @@ fi
 manager_default="$(sed -n 's/^DEFAULT_ADGUARD_PROC_OPTIMIZE="\([^"]*\)"$/\1/p' "${MANAGER_PATH}" | sed -n '1p')"
 [ "${manager_default}" = 'NO' ] || fail 'manager no-config proc optimization fallback is not disabled'
 
-printf '%s\n' 'PASS: runtime defaults preserve upgrades and apply safer new-install fallbacks'
+printf '%s\n' 'PASS: runtime defaults preserve upgrades, migrate legacy pins, and apply safer new-install fallbacks'


### PR DESCRIPTION
### Motivation

- Provide a non-interactive inspection and migration helper that reports legacy v2.6.0 runtime defaults and can write safer defaults for upgraded installs when requested. 
- Make the migration flow discoverable in the installer documentation and ensure tooling can be tested in CI without interactive prompts.

### Description

- Documented the new `sh installer migrate-runtime-defaults` command in `README.md` with usage examples for report-only, `--dry-run`, and `--yes` apply modes and added it to the list of runtime helpers. 
- Added a new test script `tests/installer-migrate-runtime-defaults.sh` that extracts installer helper functions and verifies report-only, dry-run, CLI invocation via `cli_run`, and `--yes` apply behavior while preserving custom settings. 
- Extended `tests/runtime-default-regression.sh` to assert migration dry-run and apply semantics for upgrade-pinned legacy values and updated the extraction pattern to include the new migration helpers. 
- Adjusted test scaffolding to stub interactive requirements such as `cli_require_yes`, `cli_enable_assume_yes`, and `menu` so the CLI helpers run non-interactively in tests.

### Testing

- Ran `tests/installer-migrate-runtime-defaults.sh` which executed the report-only, dry-run, and apply paths and completed successfully (prints a final PASS). 
- Ran `tests/runtime-default-regression.sh` which validated new-install defaults, upgrade preservation, migration dry-run, and migration apply paths and completed successfully (prints a final PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5552ed85908329bfae43df96ec6490)