### PR TITLE
Add split GitHub wiki pages

### DIFF
--- a/WIKI.md
+++ b/WIKI.md
@@ -2,6 +2,8 @@
 
 This wiki is a practical operator guide for installing, maintaining, and troubleshooting AdGuardHome with this installer on Asuswrt-Merlin routers.
 
+This repository also includes GitHub-wiki-ready split pages under [`wiki/`](wiki/) for publishing to `Asuswrt-Merlin-AdGuardHome-Installer.wiki.git`.
+
 ## Contents
 
 - [Supported environment](#supported-environment)

--- a/wiki/Backups-and-Restore.md
+++ b/wiki/Backups-and-Restore.md
@@ -1,0 +1,27 @@
+# Backups and Restore
+
+## Create a backup
+
+```sh
+sh installer backup --yes
+```
+
+## Restore from backup
+
+Preview the restore first:
+
+```sh
+sh installer restore --file /opt/etc/backup_AdGuardHome.tar.gz --dry-run
+```
+
+Run the restore:
+
+```sh
+sh installer restore --file /opt/etc/backup_AdGuardHome.tar.gz --yes
+```
+
+## Notes
+
+- Backup and restore paths under `/opt` require Entware and an installed or partially installed AdGuardHome environment.
+- Restore can affect DNS service. Run it during a maintenance window when possible.
+- Check `sh installer status` after restore.

--- a/wiki/Before-You-Install.md
+++ b/wiki/Before-You-Install.md
@@ -1,0 +1,28 @@
+# Before You Install
+
+## Enable JFFS scripts
+
+In the Asuswrt-Merlin web interface:
+
+1. Open **Administration**.
+2. Open **System**.
+3. Enable **JFFS custom scripts and configs**.
+4. Reboot if prompted.
+
+## Prepare Entware
+
+Install Entware on attached storage before running a full AdGuardHome install. After Entware is mounted, update packages:
+
+```sh
+opkg update && opkg upgrade
+```
+
+`opkg` is an Entware command and is valid only after Entware is available.
+
+## Check DNS ownership
+
+AdGuardHome normally listens on DNS port `53`. The installer moves dnsmasq to a managed handoff port. Before installing, identify any other service intentionally bound to port `53` and decide whether it should be stopped or reconfigured.
+
+## Use router-stock bootstrap commands
+
+Before Entware is available, use `/bin`, `/sbin`, `/usr/bin`, and `/usr/sbin` commands only. Do not use `/opt/...` paths for bootstrap commands.

--- a/wiki/Blocklist-Analysis.md
+++ b/wiki/Blocklist-Analysis.md
@@ -1,0 +1,24 @@
+# Blocklist Analysis
+
+The installer can run an unused blocklist analyzer to identify filter lists with zero query-log rule hits during the analyzed window.
+
+## Run from the installer menu
+
+Use menu option **9** when available.
+
+## Run from the command line
+
+```sh
+sh installer blocklists
+sh installer unusedblocklists
+```
+
+## Dependency note
+
+The analyzer uses Python. On routers, Python is not available in the stock PATH. If this feature is needed, install the Entware package after Entware is mounted:
+
+```sh
+opkg install python3
+```
+
+Keep this dependency separate from stock-router bootstrap steps.

--- a/wiki/DNS-Port-53-Ownership.md
+++ b/wiki/DNS-Port-53-Ownership.md
@@ -1,0 +1,24 @@
+# DNS Port 53 Ownership
+
+AdGuardHome normally owns DNS port `53`. dnsmasq is moved to a managed handoff port so router DNS features can continue to function behind AdGuardHome.
+
+## Cleanup policy
+
+Use the safer policy to refuse unknown non-dnsmasq owners of port `53`:
+
+```sh
+sh installer dns-port-policy --policy refuse-unknown
+```
+
+Use the legacy policy only when you intentionally want the older cleanup behavior:
+
+```sh
+sh installer dns-port-policy --policy legacy
+```
+
+## Operational guidance
+
+- Review port `53` ownership before changing DNS service placement.
+- Avoid broad process kills.
+- Preserve existing DNS/NVRAM values when practical.
+- Include restore logic for DNS, firewall, WAN, VPN, or service-related changes.

--- a/wiki/Developer-Validation.md
+++ b/wiki/Developer-Validation.md
@@ -1,0 +1,26 @@
+# Developer Validation
+
+The target shell is POSIX `/bin/sh` under BusyBox `ash`.
+
+## Shell syntax checks
+
+For touched shell scripts, run:
+
+```sh
+sh -n installer
+sh -n AdGuardHome.sh
+sh -n S99AdGuardHome
+sh -n rc.func.AdGuardHome
+```
+
+## Optional ShellCheck
+
+If ShellCheck is available outside the router:
+
+```sh
+shellcheck -s sh installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome
+```
+
+## Compatibility reminders
+
+Avoid Bash-only features such as `[[ ... ]]`, arrays, here-strings, process substitution, `source`, and `pipefail`. Prefer quoted variables, `printf`, `case`, and POSIX command substitution.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,36 @@
+# Asuswrt-Merlin AdGuardHome Installer Wiki
+
+Welcome to the operator wiki for the Asuswrt-Merlin AdGuardHome Installer.
+
+This wiki documents installing, updating, backing up, troubleshooting, and uninstalling AdGuardHome on supported ARM-based Asuswrt-Merlin routers.
+
+## Quick start
+
+Set a router-stock-first environment before bootstrap commands:
+
+```sh
+export LC_ALL=C
+export PATH="/sbin:/bin:/usr/sbin:/usr/bin:${PATH:-}"
+```
+
+Download and run the installer with a router-stock downloader:
+
+```sh
+/usr/sbin/curl -L -s -O https://raw.githubusercontent.com/jumpsmm7/Asuswrt-Merlin-AdGuardHome-Installer/master/installer && sh installer; rm installer
+```
+
+or:
+
+```sh
+/usr/sbin/wget -O installer https://raw.githubusercontent.com/jumpsmm7/Asuswrt-Merlin-AdGuardHome-Installer/master/installer && sh installer; rm installer
+```
+
+## Main topics
+
+- [Supported Environment](Supported-Environment)
+- [Before You Install](Before-You-Install)
+- [Installation](Installation)
+- [Installer Commands](Installer-Commands)
+- [Runtime Paths](Runtime-Paths)
+- [Service Management](Service-Management)
+- [Troubleshooting](Troubleshooting)

--- a/wiki/IPSET-Integration.md
+++ b/wiki/IPSET-Integration.md
@@ -1,0 +1,22 @@
+# IPSET Integration
+
+IPSET integration lets AdGuardHome populate ipset sets for router policy routing or firewall use.
+
+## Commands
+
+```sh
+sh installer ipset status
+sh installer ipset doctor
+sh installer ipset refresh
+sh installer ipset refresh --dry-run
+sh installer ipset refresh --yes
+```
+
+Without `--yes`, refresh checks whether IPSET integration is enabled and reports planned work. With `--yes`, the installer refreshes mappings and restarts AdGuardHome so changes can take effect.
+
+## Guidance
+
+- Handle IPv4 and IPv6 sets separately.
+- Keep rules idempotent.
+- Include cleanup for firewall rules that consume ipset sets.
+- Do not rely on `flock` unless the existing compatibility probe confirms descriptor-lock support; preserve the mkdir/PID fallback path.

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -1,0 +1,36 @@
+# Installation
+
+Open an SSH shell on the router and set a router-stock-first environment:
+
+```sh
+export LC_ALL=C
+export PATH="/sbin:/bin:/usr/sbin:/usr/bin:${PATH:-}"
+```
+
+## Install with curl
+
+```sh
+/usr/sbin/curl -L -s -O https://raw.githubusercontent.com/jumpsmm7/Asuswrt-Merlin-AdGuardHome-Installer/master/installer && sh installer; rm installer
+```
+
+## Install with wget
+
+```sh
+/usr/sbin/wget -O installer https://raw.githubusercontent.com/jumpsmm7/Asuswrt-Merlin-AdGuardHome-Installer/master/installer && sh installer; rm installer
+```
+
+## Interactive mode
+
+```sh
+sh installer
+```
+
+Follow the menu prompts for install, update, backup, restore, reconfiguration, diagnostics, or uninstall.
+
+## Non-interactive install
+
+```sh
+sh installer install --installer-branch master --adguardhome-branch release --yes --allow-dns-nvram
+```
+
+`--yes` confirms the action. `--allow-dns-nvram` is required for actions that may rewrite DNS or NVRAM settings.

--- a/wiki/Installer-Commands.md
+++ b/wiki/Installer-Commands.md
@@ -1,0 +1,43 @@
+# Installer Commands
+
+## Common commands
+
+```sh
+sh installer
+sh installer preflight
+sh installer status
+sh installer doctor
+sh installer doctor --fix
+sh installer update --dry-run
+sh installer update --yes
+sh installer backup --yes
+sh installer restore --file /opt/etc/backup_AdGuardHome.tar.gz --dry-run
+sh installer restore --file /opt/etc/backup_AdGuardHome.tar.gz --yes
+sh installer uninstall --dry-run
+sh installer uninstall --yes --allow-dns-nvram
+```
+
+## Branch selection
+
+```sh
+sh installer install --installer-branch master --adguardhome-branch release --yes --allow-dns-nvram
+sh installer update --installer-branch master --adguardhome-branch beta --yes
+sh installer update --adguardhome-branch edge --dry-run
+```
+
+Supported AdGuardHome channels are `release`, `beta`, and `edge`.
+
+## Runtime helpers
+
+```sh
+sh installer netcheck --mode wan --hosts "google.com github.com snbforums.com" --dns 127.0.0.1 --require-http NO --timeout 300
+sh installer netcheck --mode lan
+sh installer dns-port-policy --policy refuse-unknown
+sh installer dns-port-policy --policy legacy
+sh installer performance --profile balanced
+sh installer migrate-runtime-defaults
+sh installer migrate-runtime-defaults --dry-run
+sh installer migrate-runtime-defaults --yes
+```
+
+Commands referencing `/opt/...` require Entware and an installed or partially installed AdGuardHome environment.

--- a/wiki/Issue-Reports.md
+++ b/wiki/Issue-Reports.md
@@ -1,0 +1,24 @@
+# Issue Reports
+
+Please include concise, paste-safe diagnostics.
+
+## Useful commands
+
+```sh
+sh installer preflight status
+sh installer status
+sh installer doctor
+```
+
+If reporting an install, update, restore, or uninstall problem, also include the exact command you ran and whether the operation was interrupted.
+
+## Include
+
+- Router model and Asuswrt-Merlin firmware version.
+- Installer version shown by the script.
+- AdGuardHome channel: `release`, `beta`, or `edge`.
+- Whether Entware is mounted.
+- Whether JFFS custom scripts are enabled.
+- Any recent DNS, firewall, WAN, VPN, or NVRAM changes.
+
+Do not paste secrets, API tokens, private keys, or full configuration files without redacting sensitive values.

--- a/wiki/Runtime-Paths.md
+++ b/wiki/Runtime-Paths.md
@@ -1,0 +1,17 @@
+# Runtime Paths
+
+The following paths are used after Entware is installed and AdGuardHome is installed or partially staged.
+
+| Path | Purpose |
+| --- | --- |
+| `/opt/etc/AdGuardHome` | AdGuardHome configuration, data, installer `.config`, and IPSET user files. |
+| `/opt/sbin/AdGuardHome` | AdGuardHome binary symlink managed by the installer. |
+| `/opt/etc/init.d/S99AdGuardHome` | Entware init script. |
+| `/opt/etc/init.d/rc.func.AdGuardHome` | Shared service functions. |
+| `/opt/etc/backup_AdGuardHome.tar.gz` | Default backup archive location. |
+| `/jffs/addons/AdGuardHome.d` | Asuswrt-Merlin hook integration. |
+| `/jffs/scripts/dnsmasq.postconf` | dnsmasq post-configuration hook. |
+| `/jffs/scripts/firewall-start` | Firewall-start hook. |
+| `/jffs/scripts/service-event-end` | Service event hook. |
+
+Do not use `/opt/...` examples before Entware is mounted.

--- a/wiki/Service-Management.md
+++ b/wiki/Service-Management.md
@@ -1,0 +1,30 @@
+# Service Management
+
+## Recommended service commands
+
+Use Asuswrt-Merlin service events:
+
+```sh
+service start_AdGuardHome
+service stop_AdGuardHome
+service restart_AdGuardHome
+service reload_AdGuardHome
+service kill_AdGuardHome
+```
+
+`service` is a router-stock binary at `/sbin/service`.
+
+## Entware init script
+
+After Entware is mounted, the init script can be called directly:
+
+```sh
+/opt/etc/init.d/S99AdGuardHome start
+/opt/etc/init.d/S99AdGuardHome stop
+/opt/etc/init.d/S99AdGuardHome restart
+/opt/etc/init.d/S99AdGuardHome check
+/opt/etc/init.d/S99AdGuardHome reload
+/opt/etc/init.d/S99AdGuardHome kill
+```
+
+Restarting AdGuardHome can interrupt DNS service. Avoid unnecessary restarts during active network use.

--- a/wiki/Supported-Environment.md
+++ b/wiki/Supported-Environment.md
@@ -1,0 +1,26 @@
+# Supported Environment
+
+The installer targets POSIX `/bin/sh` scripts running under BusyBox `ash` on Asuswrt-Merlin routers.
+
+## Requirements
+
+- ARM-based ASUS router running Asuswrt-Merlin firmware.
+- Firmware version `384.11` or newer.
+- JFFS custom scripts and configs enabled.
+- Entware installed and mounted on attached storage before AdGuardHome runtime paths under `/opt` are used.
+- A swap file is strongly recommended; `2 GB` or larger is preferred.
+- Router stock paths before Entware paths in `PATH`.
+
+## Recommended shell environment
+
+```sh
+export LC_ALL=C
+export PATH="/sbin:/bin:/usr/sbin:/usr/bin:${PATH:-}"
+```
+
+## Compatibility notes
+
+- Do not use Bash-only syntax in installer-managed scripts.
+- Treat BusyBox applets as limited implementations.
+- Do not assume GNU coreutils behavior.
+- Commands such as `nvram`, `cru`, `service`, `iptables`, `ip6tables`, `curl`, and `wget` are router-stock binaries, not BusyBox applets.

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,0 +1,28 @@
+# Troubleshooting
+
+## First checks
+
+```sh
+sh installer status
+sh installer doctor
+sh installer preflight status
+```
+
+Use `doctor --fix` only when diagnostics recommend it:
+
+```sh
+sh installer doctor --fix
+```
+
+## Common areas to inspect
+
+- Entware is mounted and `/opt` exists.
+- JFFS custom scripts are enabled.
+- DNS port `53` is owned by the expected service.
+- dnsmasq handoff is active when AdGuardHome owns port `53`.
+- Firewall hooks are present and not duplicated.
+- Recent logs show the last startup or rollback result.
+
+## Router-safe approach
+
+Prefer syntax checks and targeted diagnostics. Avoid installing new packages or running network-heavy commands unless they are needed for the issue.

--- a/wiki/Uninstall.md
+++ b/wiki/Uninstall.md
@@ -1,0 +1,21 @@
+# Uninstall
+
+Preview uninstall actions first:
+
+```sh
+sh installer uninstall --dry-run
+```
+
+Run uninstall when ready:
+
+```sh
+sh installer uninstall --yes --allow-dns-nvram
+```
+
+`--allow-dns-nvram` is required because uninstall can restore DNS/NVRAM-related settings.
+
+## Guidance
+
+- Run uninstall during a maintenance window.
+- Confirm DNS service returns to the expected router state afterward.
+- Check for stale hooks or firewall rules if the uninstall was interrupted.

--- a/wiki/Updates.md
+++ b/wiki/Updates.md
@@ -1,0 +1,31 @@
+# Updates
+
+## Dry run
+
+```sh
+sh installer update --dry-run
+```
+
+## Update installer and AdGuardHome release channel
+
+```sh
+sh installer update --installer-branch master --adguardhome-branch release --yes
+```
+
+## Other AdGuardHome channels
+
+```sh
+sh installer update --adguardhome-branch beta --yes
+sh installer update --adguardhome-branch edge --dry-run
+```
+
+## After updating
+
+Check service state and diagnostics:
+
+```sh
+sh installer status
+sh installer doctor
+```
+
+Existing installs preserve saved runtime settings unless a migration command is explicitly run.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,18 @@
+# Navigation
+
+- [Home](Home)
+- [Supported Environment](Supported-Environment)
+- [Before You Install](Before-You-Install)
+- [Installation](Installation)
+- [Installer Commands](Installer-Commands)
+- [Runtime Paths](Runtime-Paths)
+- [Service Management](Service-Management)
+- [DNS Port 53 Ownership](DNS-Port-53-Ownership)
+- [IPSET Integration](IPSET-Integration)
+- [Blocklist Analysis](Blocklist-Analysis)
+- [Backups and Restore](Backups-and-Restore)
+- [Updates](Updates)
+- [Uninstall](Uninstall)
+- [Troubleshooting](Troubleshooting)
+- [Issue Reports](Issue-Reports)
+- [Developer Validation](Developer-Validation)


### PR DESCRIPTION
### Motivation

- Provide a set of GitHub-wiki-ready split pages so maintainers can publish structured operator documentation to `Asuswrt-Merlin-AdGuardHome-Installer.wiki.git` instead of editing a single monolithic `WIKI.md`. 
- Make the repo documentation easier to consume and navigate with a `_Sidebar.md` index and focused pages for installation, commands, runtime paths, service management, DNS/IPSET guidance, backups, updates, uninstall, troubleshooting, and developer validation. 

### Description

- Add a `wiki/` directory containing 17 Markdown pages (`Home`, `Supported-Environment`, `Before-You-Install`, `Installation`, `Installer-Commands`, `Runtime-Paths`, `Service-Management`, `DNS-Port-53-Ownership`, `IPSET-Integration`, `Blocklist-Analysis`, `Backups-and-Restore`, `Updates`, `Uninstall`, `Troubleshooting`, `Issue-Reports`, `Developer-Validation`, and `_Sidebar`) prepared for direct publishing to the GitHub wiki repo. 
- Update `WIKI.md` to note the presence of the `wiki/` split pages and point maintainers at the wiki directory for publishing. 
- Pages explicitly document router-stock-first `PATH`, POSIX `/bin/sh` BusyBox `ash` compatibility, and Entware caveats so examples avoid assuming `/opt` or Entware until mounted. 

### Testing

- Ran `git diff --check` to ensure no whitespace/patch-format issues, and it passed. 
- Verified the `wiki/` directory contains 17 Markdown files with `test "$(find wiki -maxdepth 1 -type f -name '*.md' | wc -l | tr -d ' ')" = 17`, and the test succeeded. 
- Performed a quick content preview of key files to ensure the sidebar and `WIKI.md` link text were correctly added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55a01bdc34832997fb0d5fccedb14d)