### PR TITLE
Fix preflight router mode regression test

### DIFF
--- a/tests/installer-preflight-actions.sh
+++ b/tests/installer-preflight-actions.sh
@@ -164,7 +164,7 @@ EOF
 run_router_mode_case wan 1 '' 0 \
 	'preflight.router.mode=wan' \
 	'preflight.router.mode.result=OK'
-run_router_mode_case lan 2 '' 0 \
+run_router_mode_case lan 2 192.168.50.1 0 \
 	'preflight.router.mode=lan' \
 	'preflight.router.mode.result=OK' \
 	'preflight.router.mode.note=non-router-mode-lan-install'
@@ -176,6 +176,10 @@ run_router_mode_case missing-no-lan-ip '' '' 1 \
 	'preflight.router.mode=missing' \
 	'preflight.router.mode.result=FAIL' \
 	'preflight.router.mode.reason=missing-sw-mode-and-no-usable-lan-ip'
+run_router_mode_case lan-no-lan-ip 2 '' 1 \
+	'preflight.router.mode=lan' \
+	'preflight.router.mode.result=FAIL' \
+	'preflight.router.mode.reason=non-router-mode-and-no-usable-lan-ip'
 
 (
 	# shellcheck disable=SC1090


### PR DESCRIPTION
### Motivation
- Align the regression test with recent installer behavior that requires a usable `lan_ipaddr` for non-router `sw_mode` values so CI no longer reports false passes.

### Description
- Modify `tests/installer-preflight-actions.sh` to supply a valid `lan_ipaddr` for the `lan` non-router case and add a new `lan-no-lan-ip` case that expects failure with `preflight.router.mode.reason=non-router-mode-and-no-usable-lan-ip`.

### Testing
- Ran `sh -n installer` which succeeded, `sh -n tests/installer-preflight-actions.sh` which succeeded, and executed `sh tests/installer-preflight-actions.sh` which printed `PASS: preflight action routing keeps Entware and jq checks flow-aware`.
- Ran `git diff --check` which reported no issues and attempted `shellcheck -s sh installer tests/installer-preflight-actions.sh` but `shellcheck` is unavailable in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56f2d1a8848329bfb3140a02429a2d)