### PR TITLE
test: cover installer WAN and LAN setup modes

### DIFF
--- a/tests/installer-staged-yaml-validation.sh
+++ b/tests/installer-staged-yaml-validation.sh
@@ -31,6 +31,8 @@ YAML_BAK="${TMP_ROOT}/AdGuardHome.yaml.backup"
 YAML_ERR="${TMP_ROOT}/AdGuardHome.yaml.error"
 CONF_FILE="${TMP_ROOT}/.config"
 CHECK_LOG="${TMP_ROOT}/checks"
+YESNO_LOG="${TMP_ROOT}/yesno"
+IPSET_LOG="${TMP_ROOT}/ipset"
 mkdir -p "${TARG_DIR}" || fail 'could not create test directory'
 cat >"${AGH_FILE}" <<'SCRIPT'
 #!/bin/sh
@@ -50,13 +52,36 @@ PTXT() {
 }
 read_input_num() { CHOSEN=3; }
 read_input_port() { WEB_PORT=3000; }
-read_yesno() { return 1; }
-write_conf() { :; }
+read_yesno() {
+	printf '%s\n' "$1" >>"${YESNO_LOG}"
+	case "$1" in
+		*IPSET*) return "${IPSET_YESNO_STATUS:-1}" ;;
+	esac
+	return 1
+}
+write_conf() {
+	key="$1"
+	value="$2"
+	tmp_file="${CONF_FILE}.$$"
+	if [ -f "${CONF_FILE}" ]; then
+		grep -v "^${key}=" "${CONF_FILE}" >"${tmp_file}" || :
+	else
+		: >"${tmp_file}"
+	fi
+	printf '%s=%s\n' "${key}" "${value}" >>"${tmp_file}"
+	mv -f "${tmp_file}" "${CONF_FILE}"
+}
 save_dns_filter_settings() { mkdir -p "$1"; }
 restore_dns_filter_settings() { rm -rf "$1"; }
 check_dns_filter() { :; }
 check_dns_local() { :; }
-check_ipset() { :; }
+check_ipset() {
+	printf '%s\n' "$1" >>"${IPSET_LOG}"
+	case "$1" in
+		1) write_conf ADGUARD_IPSET '"YES"' ;;
+		*) write_conf ADGUARD_IPSET '"NO"' ;;
+	esac
+}
 ipv4_is_valid() {
 	case "$1" in
 		192.168.1.1 | 192.168.50.1) return 0 ;;
@@ -99,6 +124,9 @@ check_AdGuardHome_yaml() {
 
 : >"${CONF_FILE}"
 : >"${CHECK_LOG}"
+: >"${YESNO_LOG}"
+: >"${IPSET_LOG}"
+IPSET_YESNO_STATUS=0
 
 if ! setup_AdGuardHome_impl '' install; then
 	fail 'initial setup failed'
@@ -113,14 +141,20 @@ grep -q '^schema_version: 27$' "${YAML_FILE}" || fail 'published YAML is missing
 grep -q "^  - '\[/router.asus.com/\]\[::\]:553'" "${YAML_FILE}" || fail 'WAN router upstream did not use wildcard reverse target'
 grep -q "^  - '\[::\]:553'" "${YAML_FILE}" || fail 'WAN local PTR upstream did not use wildcard reverse target'
 grep -q "^  - '\[/10.in-addr.arpa/\]\[::\]:553'" "${YAML_FILE}" || fail 'WAN private PTR upstream did not use wildcard reverse target'
+grep -q 'IPSET integration' "${YESNO_LOG}" || fail 'WAN setup did not show the IPSET prompt'
+grep -q '^1$' "${IPSET_LOG}" || fail 'WAN setup did not accept IPSET enablement'
+grep -q '^ADGUARD_IPSET="YES"$' "${CONF_FILE}" || fail 'WAN setup did not persist ADGUARD_IPSET=YES'
 [ "$(cat "${YAML_ORI}")" = "$(cat "${YAML_FILE}")" ] || fail 'original snapshot does not match published YAML'
 
-rm -f "${YAML_FILE}" "${YAML_ORI}" "${CHECK_LOG}"
+rm -f "${YAML_FILE}" "${YAML_ORI}" "${CHECK_LOG}" "${YESNO_LOG}" "${IPSET_LOG}"
 BOOTSTRAP1=
 BOOTSTRAP2=
 ADGUARD_INSTALL_MODE=lan
 ADGUARD_LAN_REVERSE_UPSTREAM=192.168.50.1
 : >"${CHECK_LOG}"
+: >"${YESNO_LOG}"
+: >"${IPSET_LOG}"
+IPSET_YESNO_STATUS=0
 if ! setup_AdGuardHome_impl '' install; then
 	fail 'LAN initial setup failed'
 fi
@@ -129,8 +163,27 @@ grep -q "^  address: 192.168.1.1:3000$" "${YAML_FILE}" || fail 'LAN web bind add
 grep -q "^  - '\[/router.asus.com/\]192.168.50.1:53'" "${YAML_FILE}" || fail 'LAN router upstream did not use LAN reverse target'
 grep -q "^  - '192.168.50.1:53'" "${YAML_FILE}" || fail 'LAN local PTR upstream did not use LAN reverse target'
 grep -q "^  - '\[/10.in-addr.arpa/\]192.168.50.1:53'" "${YAML_FILE}" || fail 'LAN private PTR upstream did not use LAN reverse target'
+if grep -q 'IPSET integration' "${YESNO_LOG}"; then
+	fail 'LAN setup showed the IPSET prompt'
+fi
+grep -q '^0$' "${IPSET_LOG}" || fail 'LAN setup did not force IPSET disabled selection'
+grep -q '^ADGUARD_IPSET="NO"$' "${CONF_FILE}" || fail 'LAN setup did not persist ADGUARD_IPSET=NO'
 
-rm -f "${YAML_FILE}" "${YAML_ORI}" "${CHECK_LOG}"
+rm -f "${YAML_FILE}" "${YAML_ORI}" "${CHECK_LOG}" "${YESNO_LOG}" "${IPSET_LOG}"
+BOOTSTRAP1=
+BOOTSTRAP2=
+ADGUARD_INSTALL_MODE=lan
+ADGUARD_LAN_REVERSE_UPSTREAM=
+: >"${CHECK_LOG}"
+: >"${YESNO_LOG}"
+: >"${IPSET_LOG}"
+if setup_AdGuardHome_impl '' install; then
+	fail 'LAN setup continued with a missing main router reverse upstream'
+fi
+[ ! -e "${YAML_FILE}" ] || fail 'LAN missing router IP wrote published YAML'
+[ ! -e "${YAML_ORI}.new.$$" ] || fail 'LAN missing router IP wrote staged YAML'
+
+rm -f "${YAML_FILE}" "${YAML_ORI}" "${CHECK_LOG}" "${YESNO_LOG}" "${IPSET_LOG}"
 BOOTSTRAP1=
 BOOTSTRAP2=
 ADGUARD_INSTALL_MODE=wan


### PR DESCRIPTION
### Motivation
- Add automated coverage for installer behavior in WAN vs LAN modes focusing on IPSET prompting, dnsmasq hook management, reverse-upstream selection, and abort-on-missing-router-IP.

### Description
- Update `tests/installer-staged-yaml-validation.sh` to record yes/no prompts and IPSET interactions via `YESNO_LOG` and `IPSET_LOG` and to persist test `write_conf` writes to the test `CONF_FILE`.
- Provide POSIX-compatible test stubs for `read_yesno`, `check_ipset`, and `write_conf` so the test can simulate accepting/declining the IPSET prompt and observe resulting `ADGUARD_IPSET` persistence.
- Add assertions that WAN setup shows and accepts the IPSET prompt and persists `ADGUARD_IPSET="YES"`, that LAN setup skips the IPSET prompt and persists `ADGUARD_IPSET="NO"`, and that LAN setup aborts before staging/publishing invalid YAML when the main router IP is missing.
- All changes are confined to the test suite (`tests/installer-staged-yaml-validation.sh`).

### Testing
- Ran `sh -n tests/installer-staged-yaml-validation.sh` and the syntax check succeeded.
- Ran `sh tests/installer-staged-yaml-validation.sh installer` and the test completed with `PASS` for the staged YAML validation scenarios.
- Ran `sh -n tests/installer-event-script-modes.sh` and `sh tests/installer-event-script-modes.sh installer` and both completed with `PASS` for event-script mode regression.
- Ran `git diff --check` which reported no issues.
- `shellcheck -s sh tests/installer-staged-yaml-validation.sh tests/installer-event-script-modes.sh` was not executed because `shellcheck` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5aeca1bba4832990399cbed3ce3b30)