### PR TITLE
test: cover S99 DNS mode lifecycle

### DIFF
--- a/tests/s99-dns-mode-lifecycle.sh
+++ b/tests/s99-dns-mode-lifecycle.sh
@@ -1,0 +1,211 @@
+#!/bin/sh
+# Verify S99AdGuardHome DNS handoff lifecycle honors WAN/LAN dnsmasq mode.
+
+set -u
+
+S99_PATH="${1:-S99AdGuardHome}"
+TEST_ROOT="${TMPDIR:-/tmp}/s99-dns-mode-lifecycle.$$"
+FUNCTIONS_FILE="${TEST_ROOT}/s99-functions"
+CALLS_FILE="${TEST_ROOT}/calls"
+
+cleanup() {
+	rm -rf "${TEST_ROOT}"
+}
+
+fail() {
+	printf '%s\n' "FAIL: $*" >&2
+	exit 1
+}
+
+trap cleanup 0
+trap 'cleanup; exit 1' HUP INT TERM
+mkdir -p "${TEST_ROOT}" || fail 'could not create test directory'
+
+sed -n \
+	'/^agh_conf_value() {$/,/^}$/p; /^agh_install_mode() {$/,/^}$/p; /^agh_dnsmasq_running() {$/,/^}$/p; /^agh_dns_handoff_required() {$/,/^}$/p; /^pre_start_adguardhome() {$/,/^}$/p; /^post_start_adguardhome() {$/,/^}$/p; /^post_start_failure_adguardhome() {$/,/^}$/p' \
+	"${S99_PATH}" >"${FUNCTIONS_FILE}" || fail "could not read ${S99_PATH}"
+[ -s "${FUNCTIONS_FILE}" ] || fail 'S99 DNS lifecycle functions were not found'
+grep -q '^pre_start_adguardhome() {$' "${FUNCTIONS_FILE}" || fail 'pre-start helper was not found'
+grep -q '^post_start_adguardhome() {$' "${FUNCTIONS_FILE}" || fail 'post-start helper was not found'
+
+# shellcheck disable=SC1090
+. "${FUNCTIONS_FILE}"
+
+PROCS='AdGuardHome'
+WORK_DIR="${TEST_ROOT}/AdGuardHome"
+DNS_HANDOFF_FILE="${TEST_ROOT}/handoff"
+mkdir -p "${WORK_DIR}" || fail 'could not create AdGuardHome work directory'
+
+agh_log() {
+	printf '%s\n' "log $*" >>"${CALLS_FILE}"
+}
+
+ensure_adguardhome_work_dir_permissions() {
+	printf '%s\n' ensure_permissions >>"${CALLS_FILE}"
+	return 0
+}
+
+adguardhome_config_valid() {
+	printf '%s\n' config_valid >>"${CALLS_FILE}"
+	return 0
+}
+
+dns_handoff_dependencies_available() {
+	printf '%s\n' handoff_dependencies >>"${CALLS_FILE}"
+	return 0
+}
+
+enable_dns_handoff() {
+	printf '%s\n' enable_dns_handoff >>"${CALLS_FILE}"
+	: >"${DNS_HANDOFF_FILE}"
+	return 0
+}
+
+disable_dns_handoff() {
+	printf '%s\n' disable_dns_handoff >>"${CALLS_FILE}"
+	rm -f "${DNS_HANDOFF_FILE}"
+	return 0
+}
+
+prepare_dns_handoff_marker() {
+	printf '%s\n' prepare_dns_handoff_marker >>"${CALLS_FILE}"
+	: >"${DNS_HANDOFF_FILE}"
+	return 0
+}
+
+remove_inactive_dns_handoff_marker() {
+	printf '%s\n' remove_inactive_marker >>"${CALLS_FILE}"
+	rm -f "${DNS_HANDOFF_FILE}"
+	return 0
+}
+
+dns_handoff_marker_is_active() {
+	[ -f "${DNS_HANDOFF_FILE}" ]
+}
+
+adguardhome_dns_bind_scope() {
+	printf '%s\n' "${DNS_BIND_SCOPE:-global}"
+}
+
+dns_retry_limit() {
+	case "${1:-}" in
+		"" | *[!0-9]*) printf '%s\n' "${2:-10}" ;;
+		*) printf '%s\n' "$1" ;;
+	esac
+}
+
+dns_port_available() {
+	printf '%s\n' "dns_port_available ${1:-global}" >>"${CALLS_FILE}"
+	[ "${DNS_PORT_AVAILABLE:-1}" -eq 1 ]
+}
+
+dns_port_needs_release() {
+	printf '%s\n' "dns_port_needs_release ${1:-global}" >>"${CALLS_FILE}"
+	return 1
+}
+
+start_dns_port_guard() {
+	printf '%s\n' start_dns_port_guard >>"${CALLS_FILE}"
+	return 0
+}
+
+stop_dns_port_guard() {
+	printf '%s\n' stop_dns_port_guard >>"${CALLS_FILE}"
+	return 0
+}
+
+save_dns_watchdog_traps() {
+	printf '%s\n' "save_traps ${1:-}" >>"${CALLS_FILE}"
+	DNS_WATCHDOG_TRAP_FILE="${TEST_ROOT}/traps"
+	return 0
+}
+
+restore_dns_watchdog_traps() {
+	printf '%s\n' "restore_traps ${1:-}" >>"${CALLS_FILE}"
+	return 0
+}
+
+resume_dns_watchdog() {
+	printf '%s\n' resume_watchdog >>"${CALLS_FILE}"
+	return 0
+}
+
+suspend_dns_watchdog() {
+	printf '%s\n' suspend_watchdog >>"${CALLS_FILE}"
+	return 0
+}
+
+wait_for_adguardhome_dns() {
+	printf '%s\n' wait_dns >>"${CALLS_FILE}"
+	case "${DNS_BIND_SCOPE:-global}" in
+		192.168.50.1) [ "${AGH_BINDS_LAN_IP:-0}" -eq 1 ] ;;
+		*) return 0 ;;
+	esac
+}
+
+wait_for_adguardhome_startup_checks() {
+	printf '%s\n' wait_startup >>"${CALLS_FILE}"
+	return 0
+}
+
+log_adguardhome_start_failure() {
+	printf '%s\n' log_start_failure >>"${CALLS_FILE}"
+}
+
+service() {
+	printf '%s\n' "service $*" >>"${CALLS_FILE}"
+	return 0
+}
+
+pidof() {
+	case "${1:-}" in
+		dnsmasq) [ "${DNSMASQ_RUNNING:-0}" -eq 1 ] && printf '%s\n' 88 ;;
+		*) return 1 ;;
+	esac
+}
+
+which() {
+	return 0
+}
+
+scribe() {
+	printf '%s\n' "scribe $*" >>"${CALLS_FILE}"
+}
+
+assert_count() {
+	pattern="$1"
+	expected="$2"
+	message="$3"
+	actual="$(grep -c "${pattern}" "${CALLS_FILE}" 2>/dev/null)"
+	[ "${actual}" -eq "${expected}" ] || fail "${message}: found ${actual}, expected ${expected}"
+}
+
+run_case() {
+	case_name="$1"
+	mode="$2"
+	dnsmasq_running="$3"
+	bind_scope="$4"
+	agh_binds_lan_ip="$5"
+	expect_handoff="$6"
+	expect_restart="$7"
+	printf '%s\n' "ADGUARD_INSTALL_MODE=\"${mode}\"" >"${WORK_DIR}/.config" || fail "${case_name}: could not write config"
+	: >"${CALLS_FILE}"
+	DNSMASQ_RUNNING="${dnsmasq_running}"
+	DNS_BIND_SCOPE="${bind_scope}"
+	AGH_BINDS_LAN_IP="${agh_binds_lan_ip}"
+	DNS_PORT_AVAILABLE=1
+	unset ADGUARDHOME_DNS_HANDOFF_ACTIVE ADGUARDHOME_DNS_HANDOFF_REQUIRED ADGUARDHOME_SKIP_DNSMASQ_RESTART ADGUARDHOME_DNS_GUARD_PID ADGUARDHOME_DNS_BIND_SCOPE
+	pre_start_adguardhome || fail "${case_name}: pre-start failed"
+	post_start_adguardhome || fail "${case_name}: post-start failed"
+	assert_count '^enable_dns_handoff$' "${expect_handoff}" "${case_name}: dnsmasq handoff call count mismatch"
+	assert_count '^service restart_dnsmasq$' "${expect_restart}" "${case_name}: dnsmasq restart count mismatch"
+	grep -q "^dns_port_available ${bind_scope}$" "${CALLS_FILE}" || fail "${case_name}: did not check configured DNS bind scope"
+	grep -q '^wait_dns$' "${CALLS_FILE}" || fail "${case_name}: post-start did not wait for AdGuardHome DNS bind"
+	grep -q '^wait_startup$' "${CALLS_FILE}" || fail "${case_name}: post-start did not run startup readiness"
+}
+
+run_case 'WAN mode' wan 0 global 0 1 1
+run_case 'LAN mode with dnsmasq running' lan 1 192.168.50.1 1 1 1
+run_case 'LAN mode without dnsmasq' lan 0 192.168.50.1 1 0 0
+
+printf '%s\n' 'PASS: S99 DNS handoff lifecycle honors WAN/LAN dnsmasq mode'

--- a/tests/s99-netstat-readiness.sh
+++ b/tests/s99-netstat-readiness.sh
@@ -21,7 +21,7 @@ trap 'cleanup; exit 1' HUP INT TERM
 mkdir -p "${TEST_ROOT}" || fail 'could not create test directory'
 
 sed -n \
-	'/^adguardhome_web_port() {$/,/^}$/p; /^adguardhome_web_port_owned_status() {$/,/^}$/p; /^adguardhome_web_port_available() {$/,/^}$/p; /^dns_retry_limit() {$/,/^}$/p; /^adguardhome_single_process_running() {$/,/^}$/p; /^adguardhome_owns_dns() {$/,/^}$/p; /^dns_port_available() {$/,/^}$/p; /^dns_port_has_foreign_owner() {$/,/^}$/p; /^dns_port_needs_release() {$/,/^}$/p; /^log_adguardhome_dns_wait_failure() {$/,/^}$/p' \
+	'/^adguardhome_web_port() {$/,/^}$/p; /^adguardhome_web_port_owned_status() {$/,/^}$/p; /^adguardhome_web_port_available() {$/,/^}$/p; /^dns_retry_limit() {$/,/^}$/p; /^adguardhome_single_process_running() {$/,/^}$/p; /^adguardhome_owns_dns() {$/,/^}$/p; /^dns_port_owner_command() {$/,/^}$/p; /^dns_port_owner_process_name() {$/,/^}$/p; /^dns_port_unknown_refusal_enabled() {$/,/^}$/p; /^kill_dns_port_owners() {$/,/^}$/p; /^dns_port_available() {$/,/^}$/p; /^dns_port_has_foreign_owner() {$/,/^}$/p; /^dns_port_needs_release() {$/,/^}$/p; /^log_adguardhome_dns_wait_failure() {$/,/^}$/p' \
 	"${S99_PATH}" >"${FUNCTIONS_FILE}" || fail "could not read ${S99_PATH}"
 [ -s "${FUNCTIONS_FILE}" ] || fail 'S99 netstat readiness functions were not found'
 grep -q '^adguardhome_single_process_running() {$' "${FUNCTIONS_FILE}" || fail 'single-process fallback helper was not found'
@@ -76,6 +76,16 @@ netstat() {
 				'udp 0 0 0.0.0.0:53 0.0.0.0:*' \
 				'tcp 0 0 0.0.0.0:3000 0.0.0.0:* LISTEN 88/httpd'
 			;;
+		unknown_other_lan_ip)
+			printf '%s\n' \
+				'tcp 0 0 192.168.50.2:53 0.0.0.0:* LISTEN 77/customdns' \
+				'udp 0 0 192.168.50.2:53 0.0.0.0:* 77/customdns'
+			;;
+		unknown_configured_lan_ip)
+			printf '%s\n' \
+				'tcp 0 0 192.168.50.1:53 0.0.0.0:* LISTEN 77/customdns' \
+				'udp 0 0 192.168.50.1:53 0.0.0.0:* 77/customdns'
+			;;
 		missing_udp)
 			printf '%s\n' \
 				'tcp 0 0 0.0.0.0:53 0.0.0.0:* LISTEN' \
@@ -87,6 +97,11 @@ netstat() {
 				'tcp 0 0 0.0.0.0:3000 0.0.0.0:* LISTEN'
 			;;
 	esac
+}
+
+kill() {
+	printf '%s\n' "kill $*" >>"${CALLS_FILE}"
+	return 0
 }
 
 PIDOF_STATE=one
@@ -138,6 +153,22 @@ NETSTAT_STATE=foreign_web
 if adguardhome_web_port_available; then
 	fail 'WebUI readiness accepted explicit foreign ownership'
 fi
+
+NETSTAT_STATE=unknown_other_lan_ip
+ADGUARDHOME_FORCE_DNS_PORT_KILL=1
+if ! kill_dns_port_owners 192.168.50.1; then
+	fail 'scoped release rejected unrelated unknown owner on a different LAN IP'
+fi
+[ ! -s "${CALLS_FILE}" ] || fail 'scoped release logged or killed unrelated unknown owner on a different LAN IP'
+
+NETSTAT_STATE=unknown_configured_lan_ip
+: >"${CALLS_FILE}"
+if ! kill_dns_port_owners 192.168.50.1; then
+	fail 'scoped forced release rejected unknown owner on configured LAN IP'
+fi
+grep -q '^kill -s 9 77$' "${CALLS_FILE}" || fail 'scoped forced release did not kill unknown owner on configured LAN IP'
+
+unset ADGUARDHOME_FORCE_DNS_PORT_KILL
 
 NETSTAT_STATE=missing_udp
 if adguardhome_owns_dns; then

--- a/tools/code-quality.sh
+++ b/tools/code-quality.sh
@@ -147,6 +147,8 @@ run_check 'Installer IPSET preference save failure regression' sh tests/installe
 run_check 'Installer setup IPSET preference save failure regression' sh tests/installer-ipset-setup-save-failure.sh
 run_check 'AdGuardHome permission repair regression' sh tests/adguardhome-permissions.sh
 run_check 'AdGuardHome startup lifecycle regression' sh tests/start-adguardhome-lifecycle.sh
+run_check 'AdGuardHome S99 DNS mode lifecycle regression' sh tests/s99-dns-mode-lifecycle.sh
+run_check 'AdGuardHome S99 netstat readiness regression' sh tests/s99-netstat-readiness.sh
 run_check 'AdGuardHome stop failure regression' sh tests/stop-adguardhome-failure.sh
 run_check 'AdGuardHome monitor retry backoff regression' sh tests/monitor-retry-backoff.sh
 run_check 'AdGuardHome DNS startup handoff regression' run_dns_handoff_check


### PR DESCRIPTION
### Motivation

- Add focused unit tests to validate S99AdGuardHome DNS handoff semantics across WAN and LAN install modes and to ensure dnsmasq is only restarted when appropriate.
- Exercise scoped DNS port owner handling so unrelated unknown owners on other LAN IPs are not terminated while conflicts on the configured LAN IP can be forcibly released.

### Description

- Add `tests/s99-dns-mode-lifecycle.sh`, a new test that extracts `pre_start_adguardhome`/`post_start_adguardhome`/failure helpers from `S99AdGuardHome` and simulates WAN, LAN-with-dnsmasq, and LAN-without-dnsmasq flows to assert handoff and restart behavior.
- Extend `tests/s99-netstat-readiness.sh` to extract owner-related helpers (`dns_port_owner_command`, `dns_port_owner_process_name`, `dns_port_unknown_refusal_enabled`, `kill_dns_port_owners`) and add simulated `netstat` fixtures for unknown owners scoped to other LAN IPs and the configured LAN IP.
- Add a `kill()` test stub and assertions that verify unknown owners on unrelated LAN IPs are ignored and that `ADGUARDHOME_FORCE_DNS_PORT_KILL=1` allows killing an owner bound to the configured LAN IP.

### Testing

- Ran syntax checks with `sh -n tests/s99-dns-mode-lifecycle.sh tests/s99-netstat-readiness.sh`, which passed. 
- Executed `tests/s99-dns-mode-lifecycle.sh S99AdGuardHome`, which passed. 
- Executed `tests/s99-netstat-readiness.sh S99AdGuardHome`, which passed and includes the new unknown-owner assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5af2b556f48329890c3cd32eec3ebc)