### PR TITLE
Use portable which lookup in DNS regression harness

### DIFF
--- a/tests/installer-dns-environment-failure.sh
+++ b/tests/installer-dns-environment-failure.sh
@@ -18,7 +18,7 @@ trap cleanup 0
 trap 'cleanup; exit 1' HUP INT TERM
 mkdir -p "${TEST_ROOT}" || fail 'could not create test workspace'
 
-printf '%s\n' 'which() { command -v "$1" >/dev/null 2>&1; }' >"${FUNCTIONS_FILE}" || fail 'could not create test functions file'
+: >"${FUNCTIONS_FILE}" || fail 'could not create test functions file'
 sed -n '/^nvram_transaction_begin() {$/,/^installer_lan_domain_set() {$/p' "${INSTALLER_PATH}" |
 	sed -e '$d' -e 's|/bin/nvram|nvram|g' -e 's|/bin/grep|grep|g' >>"${FUNCTIONS_FILE}" || fail 'could not extract NVRAM transaction helpers'
 sed -n '/^installer_lan_domain_set() {$/,/^rollback_result_write() {$/p' "${INSTALLER_PATH}" | sed -e '$d' -e 's|/bin/nvram|nvram|g' -e 's|/bin/grep|grep|g' >>"${FUNCTIONS_FILE}" || fail 'could not extract LAN-domain transaction helpers'
@@ -47,7 +47,6 @@ PTXT() { printf '%s\n' "$*" >>"${CALLS_FILE}"; }
 ptxt_phase() { PTXT "$1"; }
 ptxt_step() { PTXT "$1"; }
 ptxt_ok() { PTXT "$1"; }
-which() { command -v "$1" >/dev/null 2>&1; }
 pidof() {
 	[ "${STUBBY_RUNNING:-0}" = 1 ] && [ "$1" = stubby ] || return 1
 	printf '%s\n' 1234


### PR DESCRIPTION
### Motivation
- The DNS environment regression harness defined a `which()` helper using `command -v`, which conflicts with the repository portability guidance that uses the system `which` on the target BusyBox `/bin/sh` environment and can break test execution.

### Description
- Removed the `command -v`-backed `which()` override from `tests/installer-dns-environment-failure.sh` so extracted installer helpers use the system `which`, and kept the existing assertions that transaction helpers use `/bin/nvram` and `/bin/grep`.

### Testing
- Ran syntax and regression checks including `sh -n tests/installer-dns-environment-failure.sh` and `sh tests/installer-dns-environment-failure.sh`, and both succeeded; `sh tools/check-md5.sh` and `sh tools/check-sha256.sh` also succeeded; `git diff --check` passed; `sh tools/code-quality.sh` progressed through the regression suite and the updated DNS regression ran successfully (the aggregate harness run progressed but the execution harness terminated before an overall final status).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66f7f74434832992bde657680680c7)