### PR TITLE
tests: cover stubby restart failure in DNS environment regression

### DIFF
--- a/tests/installer-dns-environment-failure.sh
+++ b/tests/installer-dns-environment-failure.sh
@@ -134,12 +134,11 @@ service() {
 		restart_dnsmasq | 'restart_firewall;restart_dnsmasq') ;;
 		restart_stubby)
 			STUBBY_RESTART_COUNT="$((STUBBY_RESTART_COUNT + 1))"
-			return 0
 			;;
 		*) return 1 ;;
 	esac
 	SERVICE_COUNT="$((SERVICE_COUNT + 1))"
-	printf '%s\n' 'service restart_dnsmasq' >>"${CALLS_FILE}"
+	printf '%s\n' "service $*" >>"${CALLS_FILE}"
 	[ "${FAIL_ALL_SERVICES:-0}" = 0 ] && [ "${FAIL_SERVICE_AT:-0}" != "${SERVICE_COUNT}" ]
 }
 
@@ -183,7 +182,7 @@ EOF_NVRAM
 	BLOCKING_QUERY=0 TRACK_LOOKUP=0 MONOTONIC_NOW=0 MONOTONIC_FAIL_AT=0 STUBBY_RUNNING=0
 	DNS_ENV_READY_TIMEOUT=2 DNS_ENV_RECOVERY_TIMEOUT=1
 	rm -f "${TEST_ROOT}/monotonic-calls" "${TEST_ROOT}/lookup-reaped"
-	_DNS_NVRAM_SAVED=0 _DNS_NVRAM_ROLLBACK_ATTEMPTED=0
+	_DNS_STUBBY_STOPPED=0 _DNS_NVRAM_SAVED=0 _DNS_NVRAM_ROLLBACK_ATTEMPTED=0
 }
 
 reset_case
@@ -665,7 +664,7 @@ EOF_NVRAM
 STUBBY_RUNNING=1
 FAIL_SERVICE_AT=1
 check_dns_environment 0 && fail 'initial dnsmasq restart failure after stopping stubby was accepted'
-[ "${SERVICE_COUNT}" = 2 ] || fail 'dnsmasq restart failure after stopping stubby was not retried'
+[ "${SERVICE_COUNT}" = 3 ] || fail 'dnsmasq restart failure was not retried before stubby recovery'
 [ "$(dns_check_count)" = 1 ] || fail 'recovered dnsmasq restart after stopping stubby was not checked'
 [ ! -e "${BASE_DIR}/.AdGuardHome.nvram/dns-preparation" ] || fail 'successful dnsmasq recovery retained its snapshot'
 
@@ -679,7 +678,7 @@ EOF_NVRAM
 STUBBY_RUNNING=1
 FAIL_ALL_SERVICES=1
 check_dns_environment 0 && fail 'unrecoverable dnsmasq restart failure after stopping stubby was accepted'
-[ "${SERVICE_COUNT}" = 2 ] || fail 'unrecoverable dnsmasq restart failure was not retried before returning'
+[ "${SERVICE_COUNT}" = 3 ] || fail 'unrecoverable dnsmasq restart failure and stubby recovery were not attempted before returning'
 [ -f "${BASE_DIR}/.AdGuardHome.nvram/dns-preparation/dirty" ] || fail 'unrecoverable dnsmasq restart failure did not preserve recovery state'
 grep -q 'snapshot preserved' "${CALLS_FILE}" || fail 'unrecoverable dnsmasq restart failure did not record rollback evidence'
 [ "${STUBBY_RESTART_COUNT}" = 1 ] || fail 'unrecoverable DNS preparation did not restore stubby'
@@ -691,6 +690,18 @@ check_dns_environment 0 && fail 'DNS staging failure after stopping stubby was a
 [ "${STUBBY_RESTART_COUNT}" = 1 ] || fail 'DNS staging failure did not restore stubby'
 
 reset_case
+STUBBY_RUNNING=1
+FAIL_SET_AT=1
+FAIL_SERVICE_AT=2
+check_dns_environment 0 && fail 'stubby restore failure after DNS staging failure was accepted'
+[ "${SERVICE_COUNT}" = 2 ] || fail 'stubby restore failure did not participate in service failure injection'
+[ "${STUBBY_RESTART_COUNT}" = 1 ] || fail 'stubby restore failure was not attempted exactly once'
+grep -q '^service restart_stubby$' "${CALLS_FILE}" || fail 'stubby restore failure was not recorded'
+grep -q 'Unable to restart stubby after DNS preparation failed.' "${CALLS_FILE}" || fail 'stubby restore failure was not reported'
+[ "${_DNS_STUBBY_STOPPED}" = 1 ] || fail 'stubby restore failure did not preserve stopped state for later recovery'
+
+reset_case
+[ "${_DNS_STUBBY_STOPPED}" = 0 ] || fail 'reset leaked stopped stubby state from the previous case'
 STUBBY_RUNNING=1
 FAIL_COMMIT_AT=1
 check_dns_environment 0 && fail 'DNS apply failure after stopping stubby was accepted'

--- a/tests/installer-dns-environment-failure.sh
+++ b/tests/installer-dns-environment-failure.sh
@@ -51,7 +51,7 @@ ptxt_phase() { PTXT "$1"; }
 ptxt_step() { PTXT "$1"; }
 # ptxt_ok writes a success message to the test call log.
 ptxt_ok() { PTXT "$1"; }
-# pidof reports the simulated PID when the requested process is stubby and it is configured as running.
+# pidof reports PID 1234 when the requested process is stubby and it is configured as running.
 pidof() {
 	[ "${STUBBY_RUNNING:-0}" = 1 ] && [ "$1" = stubby ] || return 1
 	printf '%s\n' 1234
@@ -79,7 +79,7 @@ monotonic_seconds() {
 	fi
 	printf '%s\n' "${MONOTONIC_NOW}"
 }
-# check_connection checks simulated public network availability and increments the public connectivity check count.
+# check_connection checks whether the simulated public network is available and increments the connectivity check count.
 check_connection() {
 	PUBLIC_CHECK_COUNT="$((PUBLIC_CHECK_COUNT + 1))"
 	[ "${PUBLIC_NETWORK_AVAILABLE:-0}" = 1 ]
@@ -128,7 +128,7 @@ nvram() {
 	esac
 }
 
-# service simulates restarting dnsmasq and records whether the configured service operation succeeds.
+# service simulates supported service restarts and reports whether the configured failure injection permits them.
 service() {
 	case "$*" in
 		restart_dnsmasq | 'restart_firewall;restart_dnsmasq') ;;
@@ -234,7 +234,7 @@ done
 for reaper_path in "${BASE_DIR}/.AdGuardHome.nvram.lock.symlink.reaper" "${BASE_DIR}/.AdGuardHome.nvram.lock.reaper"; do
 	rm -rf "${reaper_path}"
 	(
-		# nvram_transaction_lock_owner_current fails to ensure explicit-owner reaper operations do not perform an owner lookup.
+		# nvram_transaction_lock_owner_current reports an error and fails when an owner lookup is invoked unexpectedly.
 		nvram_transaction_lock_owner_current() {
 			printf '%s\n' 'Error: owner lookup invoked unexpectedly while an explicit owner was supplied' >&2
 			return 1
@@ -411,7 +411,7 @@ BASE_DIR="${BASE_DIR}" FUNCTIONS_FILE="${FUNCTIONS_FILE}" TEST_ROOT="${TEST_ROOT
 	installer_lan_domain_restore() { :; }
 	# restore_dns_filter_settings restores DNSFilter settings and returns a failure status.
 	restore_dns_filter_settings() { return 1; }
-	# check_dns_environment prepares the local DNS environment, verifies readiness within bounded time, and restores transactional NVRAM state when requested.
+	# check_dns_environment prepares the local DNS environment, verifies local DNS readiness within bounded deadlines, and restores transactional NVRAM state when requested.
 	check_dns_environment() { :; }
 	# nvram_transaction_lock_owned reports that the current process owns the NVRAM transaction lock.
 	nvram_transaction_lock_owned() { return 0; }
@@ -458,9 +458,9 @@ EOF_RESTART
 		chmod 755 "${TARG_DIR}/installer" || fail "could not make ${fallback_mode} restart target executable"
 		# sleep does nothing.
 		sleep() { :; }
-		# clear_screen does nothing.
+		# clear_screen performs no action.
 		clear_screen() { :; }
-		# rollback_result_needs_attention indicates whether rollback requires attention and returns failure when it does not.
+		# rollback_result_needs_attention reports that rollback does not require attention.
 		rollback_result_needs_attention() { return 1; }
 		end_op_message 0 ''
 	) || fail "installer restart retained its ${fallback_mode} NVRAM transaction lock"
@@ -492,7 +492,7 @@ done
 	# nvram_transaction_lock_flock_supports_fd reports whether file-descriptor-based flock locking is supported.
 	nvram_transaction_lock_flock_supports_fd() { return 1; }
 	ln -s 999999 "${BASE_DIR}/.AdGuardHome.nvram.lock.symlink" || fail 'could not prepare raced stale symlink transaction lock'
-	# nvram_transaction_lock_reaper_acquire replaces the transaction lock symlink with a reaper ownership marker.
+	# nvram_transaction_lock_reaper_acquire acquires the NVRAM transaction lock for reaping by replacing its symlink with a reaper marker.
 	nvram_transaction_lock_reaper_acquire() {
 		rm -f "${BASE_DIR}/.AdGuardHome.nvram.lock.symlink" || return 1
 		ln -s 1 "${BASE_DIR}/.AdGuardHome.nvram.lock.symlink"
@@ -560,7 +560,7 @@ done
 	nvram_transaction_lock_symlink_acquire() { return 2; }
 	mkdir "${BASE_DIR}/.AdGuardHome.nvram.lock.d" || fail 'could not prepare raced stale mkdir transaction lock'
 	printf '%s\n' 999999999 >"${BASE_DIR}/.AdGuardHome.nvram.lock.d/pid" || fail 'could not record raced stale mkdir transaction lock owner'
-	# nvram_transaction_lock_reaper_acquire creates the NVRAM transaction lock reaper directory and writes its ownership marker.
+	# nvram_transaction_lock_reaper_acquire recreates the NVRAM transaction lock reaper directory and records its owner marker.
 	nvram_transaction_lock_reaper_acquire() {
 		rm -rf "${BASE_DIR}/.AdGuardHome.nvram.lock.d" || return 1
 		mkdir "${BASE_DIR}/.AdGuardHome.nvram.lock.d" || return 1
@@ -585,7 +585,8 @@ done
 	: >"${OWNER_CALLS_FILE}"
 	# nvram_transaction_lock_owner_current counts self-owner lookups while preserving the real liveness check for other PIDs.
 	# nvram_transaction_lock_owner_current returns the current lock owner or a PID and process-start-time identifier for the specified process.
-	# shellcheck disable=SC2120 # invoked with a PID argument by nvram_transaction_lock_acquire in the sourced installer script
+	# nvram_transaction_lock_owner_current returns the current lock owner or a PID and process start-time identifier for a numeric PID.
+	# shellcheck disable=SC2120 # called with a PID argument from the sourced installer script
 	nvram_transaction_lock_owner_current() {
 		if [ "$#" -eq 0 ]; then
 			printf '%s\n' x >>"${OWNER_CALLS_FILE}"

--- a/tests/installer-dns-environment-failure.sh
+++ b/tests/installer-dns-environment-failure.sh
@@ -139,7 +139,13 @@ service() {
 	esac
 	SERVICE_COUNT="$((SERVICE_COUNT + 1))"
 	printf '%s\n' "service $*" >>"${CALLS_FILE}"
-	[ "${FAIL_ALL_SERVICES:-0}" = 0 ] && [ "${FAIL_SERVICE_AT:-0}" != "${SERVICE_COUNT}" ]
+	if [ "${FAIL_ALL_SERVICES:-0}" = 0 ] && [ "${FAIL_SERVICE_AT:-0}" != "${SERVICE_COUNT}" ]; then
+		case "$*" in
+			restart_stubby) STUBBY_RUNNING=1 ;;
+		esac
+		return 0
+	fi
+	return 1
 }
 
 # rm removes files and directories, failing when configured to simulate removal of the active NVRAM transaction directory.
@@ -699,6 +705,14 @@ check_dns_environment 0 && fail 'stubby restore failure after DNS staging failur
 grep -q '^service restart_stubby$' "${CALLS_FILE}" || fail 'stubby restore failure was not recorded'
 grep -q 'Unable to restart stubby after DNS preparation failed.' "${CALLS_FILE}" || fail 'stubby restore failure was not reported'
 [ "${_DNS_STUBBY_STOPPED}" = 1 ] || fail 'stubby restore failure did not preserve stopped state for later recovery'
+
+reset_case
+STUBBY_RUNNING=1
+FAIL_SET_AT=1
+check_dns_environment 0 && fail 'successful stubby restore after DNS staging failure was unexpectedly accepted'
+[ "${STUBBY_RESTART_COUNT}" = 1 ] || fail 'successful stubby restore was not attempted exactly once'
+[ "${STUBBY_RUNNING}" = 1 ] || fail 'successful stubby restore did not set stubby to running state'
+grep -q '^service restart_stubby$' "${CALLS_FILE}" || fail 'successful stubby restore was not recorded'
 
 reset_case
 [ "${_DNS_STUBBY_STOPPED}" = 0 ] || fail 'reset leaked stopped stubby state from the previous case'

--- a/tests/installer-dns-input-failure.sh
+++ b/tests/installer-dns-input-failure.sh
@@ -52,10 +52,13 @@ trap cleanup 0
 trap 'cleanup; exit 1' HUP INT TERM
 
 ptxt_ok() { :; }
+# PTXT prints each argument on a separate line.
 PTXT() {
 	printf '%s\n' "$@"
 }
+# read_input_num sets the selected numeric option to 3.
 read_input_num() { CHOSEN=3; }
+# read_input_port sets the WebUI port to 3000.
 read_input_port() { WEB_PORT=3000; }
 # write_conf records configuration writes and updates the stubbed AdGuard Home domain preference.
 write_conf() {
@@ -70,7 +73,7 @@ AdGuardHome_authen() {
 }
 # check_AdGuardHome_yaml is a test stub that reports the AdGuard Home YAML configuration as valid.
 check_AdGuardHome_yaml() { return 0; }
-# check_dns_filter records a DNS filter check and fails when nested DNS prompt failure is enabled.
+# check_dns_filter records a DNS filter check and returns status 2 when nested DNS prompt failure is enabled.
 check_dns_filter() {
 	DNS_FILTER_CALLS="$((DNS_FILTER_CALLS + 1))"
 	[ "${FAIL_NESTED_DNS_PROMPT:-0}" -eq 1 ] && return 2

--- a/tests/installer-ipset-setup-save-failure.sh
+++ b/tests/installer-ipset-setup-save-failure.sh
@@ -59,15 +59,15 @@ check_dns_filter() { :; }
 save_dns_filter_settings() { mkdir -p "$1"; }
 # installer_lan_domain_set writes the specified LAN domain to NVRAM.
 installer_lan_domain_set() { nvram set "lan_domain=$1"; }
-# installer_lan_domain_restore restores the installer LAN domain setting.
+# installer_lan_domain_restore leaves the installer LAN domain setting unchanged.
 installer_lan_domain_restore() { :; }
 # restore_dns_filter_settings removes the specified DNS filter settings directory and its contents.
 restore_dns_filter_settings() { rm -rf "$1"; }
 # check_dns_local performs the DNS locality check.
 check_dns_local() { :; }
-# check_ipset reports whether the IPSET preference check succeeds.
+# check_ipset simulates a failed IPSET preference check.
 check_ipset() { return 1; }
-# check_AdGuardHome_yaml validates the AdGuardHome YAML configuration when validation is enabled and fails otherwise.
+# check_AdGuardHome_yaml verifies that YAML validation is enabled for the test harness.
 check_AdGuardHome_yaml() {
 	[ "${ALLOW_YAML_VALIDATION:-0}" -eq 1 ] || fail 'unexpected YAML validation'
 }

--- a/tests/installer-lan-startup-generation.sh
+++ b/tests/installer-lan-startup-generation.sh
@@ -89,7 +89,7 @@ save_dns_filter_settings() { mkdir -p "$1"; }
 installer_lan_domain_set() { nvram set "lan_domain=$1"; }
 # installer_lan_domain_restore restores the configured LAN domain.
 installer_lan_domain_restore() { :; }
-# restore_dns_filter_settings removes the specified directory and its contents.
+# restore_dns_filter_settings removes the specified directory and all of its contents.
 restore_dns_filter_settings() { rm -rf "$1"; }
 # check_dns_filter is a no-op test stub for DNS filter checks.
 check_dns_filter() { :; }

--- a/tests/installer-staged-yaml-validation.sh
+++ b/tests/installer-staged-yaml-validation.sh
@@ -56,7 +56,7 @@ PTXT() {
 read_input_num() { CHOSEN=3; }
 # read_input_port sets the web interface port to 3000.
 read_input_port() { WEB_PORT=3000; }
-# read_yesno records the prompt and returns the configured response for IPSET prompts.
+# read_yesno records a prompt and returns its configured response for IPSET prompts.
 read_yesno() {
 	printf '%s\n' "$1" >>"${YESNO_LOG}"
 	case "$1" in

--- a/tests/installer-update-reexec-lock.sh
+++ b/tests/installer-update-reexec-lock.sh
@@ -35,10 +35,10 @@ for lock_mode in flock symlink mkdir; do
 		flock)
 			[ -x /usr/bin/flock ] || continue
 			;;
-		symlink) # nvram_transaction_lock_flock_supports_fd indicates that file-descriptor-based flock locking is unavailable.
+		symlink) # nvram_transaction_lock_flock_supports_fd determines whether file-descriptor-based flock locking is available.
 			nvram_transaction_lock_flock_supports_fd() { return 1; } ;;
 		mkdir)
-			# nvram_transaction_lock_flock_supports_fd indicates that file-descriptor-based flock locking is unavailable.
+			# nvram_transaction_lock_flock_supports_fd determines whether file-descriptor-based flock locking is available.
 			nvram_transaction_lock_flock_supports_fd() { return 1; }
 			# nvram_transaction_lock_symlink_acquire reports that symlink lock acquisition is unavailable.
 			nvram_transaction_lock_symlink_acquire() { return 2; }

--- a/tests/installer-web-port-failure.sh
+++ b/tests/installer-web-port-failure.sh
@@ -66,7 +66,7 @@ trap 'cleanup; exit 1' HUP INT TERM
 ptxt_ok() { :; }
 # PTXT is a no-op text output helper.
 PTXT() { :; }
-# rm removes files normally and simulates failure for configured LAN-domain or DNS-filter snapshot cleanup paths.
+# rm removes files normally and simulates configured cleanup failures for LAN-domain or DNS-filter snapshot markers.
 rm() {
 	if [ "${FAIL_LAN_DOMAIN_SNAPSHOT_CLEANUP:-0}" -eq 1 ] &&
 		[ "$*" = "-f ${BASE_DIR}/.AdGuardHome.nvram/lan-domain/dirty" ]; then
@@ -113,12 +113,12 @@ check_AdGuardHome_yaml() {
 DNS_FILTER_CHANGED=0
 DNS_FILTER_RESTORES=0
 LAN_DOMAIN_RESTORES=0
-# save_dns_filter_settings saves DNS filter settings to the specified directory.
+# save_dns_filter_settings saves DNS filter settings to the specified directory and creates a DNS filter snapshot for rollback.
 save_dns_filter_settings() {
 	mkdir -p "$1"
 	mkdir -p "${BASE_DIR}/.AdGuardHome.nvram/dnsfilter"
 }
-# installer_lan_domain_set sets the LAN domain to the specified value.
+# installer_lan_domain_set records the current LAN domain and sets it to the specified value, returning failure when persistence is configured to fail.
 installer_lan_domain_set() {
 	[ "${FAIL_LAN_DOMAIN_SET:-0}" -eq 0 ] || return 1
 	TEST_LAN_DOMAIN_ROLLBACK="${LAN_DOMAIN:-}"
@@ -140,7 +140,7 @@ restore_dns_filter_settings() {
 	rm -rf "$1"
 	rm -rf "${BASE_DIR}/.AdGuardHome.nvram/dnsfilter"
 }
-# check_dns_filter marks the DNS filter settings as changed.
+# check_dns_filter marks the DNS filter settings as changed and fails when configured to simulate an update failure.
 check_dns_filter() {
 	DNS_FILTER_CHANGED=1
 	if [ "${FAIL_CHECK_DNS_FILTER:-0}" -eq 1 ]; then
@@ -148,6 +148,7 @@ check_dns_filter() {
 		return 1
 	fi
 }
+# check_dns_local appends a changed local DNS setting to the installer configuration.
 check_dns_local() {
 	printf '%s\n' 'ADGUARD_LOCAL="CHANGED"' >>"${CONF_FILE}"
 }
@@ -156,6 +157,7 @@ check_ipset() {
 }
 read_yesno() { return 1; }
 AdGuardHome_authen() { :; }
+# read_input_dns sets the first or second bootstrap DNS server based on whether the first server is already configured.
 read_input_dns() {
 	if [ -z "${BOOTSTRAP1:-}" ]; then
 		BOOTSTRAP1=9.9.9.9
@@ -163,8 +165,9 @@ read_input_dns() {
 		BOOTSTRAP2=8.8.8.8
 	fi
 }
+# ai_have_cmd indicates that the requested command is unavailable.
 ai_have_cmd() { return 1; }
-# nvram mocks NVRAM get and set operations for installer tests.
+# nvram mocks NVRAM reads and writes used by installer tests.
 nvram() {
 	case "$1:${2:-}" in
 		get:dns_local_cache) printf '%s\n' '1' ;;


### PR DESCRIPTION
### Motivation
- Make DNS environment failure tests exercise `restart_stubby` failure paths so the installer’s stubby restore logic is validated under service-failure injection.
- Ensure test isolation by clearing leaked stubby state between cases to avoid order-dependent results.

### Description
- Updated the test service mock in `tests/installer-dns-environment-failure.sh` so the `restart_stubby` branch participates in the shared service failure injection and still increments `STUBBY_RESTART_COUNT`, and recorded service calls now use `service $*` for accurate logging.
- Cleared `_DNS_STUBBY_STOPPED` in `reset_case` so stopped-stubby state does not leak between test cases.
- Added a focused failure case that injects a `restart_stubby` failure (`FAIL_SERVICE_AT`/`FAIL_SET_AT`), asserts the service-count interaction, verifies the call was recorded, checks the error reporting, and verifies that stopped-state is preserved for later recovery.
- Adjusted related `SERVICE_COUNT` assertions where the additional recorded stubby action affects the expected counts.

### Testing
- Ran syntax check: `sh -n tests/installer-dns-environment-failure.sh` (succeeded).
- Executed the regression: `sh tests/installer-dns-environment-failure.sh` (all new and existing assertions passed).
- Ran quick repository checks: `git diff --check` (no whitespace errors) and `sh tools/code-quality.sh` (required regressions and checksum checks passed; final aggregate nonzero only due to optional host tools `shellcheck`/`shfmt` being unavailable).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6831e9f33c832994cc19d710a72fe9)