### PR TITLE
Pass review summary bodies via files to avoid shell interpolation (qodo-pr-resolver)

### DIFF
--- a/tests/qodo-pr-resolver-doc-consistency.sh
+++ b/tests/qodo-pr-resolver-doc-consistency.sh
@@ -60,6 +60,41 @@ if grep -Fq "glab mr comment <mr-iid> --message '<comment-body>'" "${PROVIDERS}"
 	fail "${PROVIDERS}: unsafe shell-quoted GitLab summary example is present"
 fi
 
+# --- Generic validation: scan every gh/glab summary-posting command in the
+# file to ensure none use inline --body/--message/--description with dynamic
+# content (anything other than safe file-read patterns like $(cat "$FILE")).
+# This catches unsafe variants regardless of placeholder text or argument order.
+UNSAFE_COMMANDS=$(mktemp "${TMPDIR:-/tmp}/unsafe_commands.XXXXXX") || exit 1
+trap 'rm -f "$UNSAFE_COMMANDS"' EXIT
+grep -E '(gh pr (comment|create)|glab mr (comment|note|create))' "${PROVIDERS}" | while IFS= read -r line; do
+	# Skip lines that use safe file-based patterns:
+	# - --body-file "$..."
+	# - < "$COMMENT_FILE" or similar redirection
+	# - --body "$(cat "$FILE")" (reading from file is safe)
+	# - --description "$(cat "$FILE")" (reading from file is safe)
+	case "$line" in
+		*'--body-file'*) continue ;;
+		*'< "$'*) continue ;;
+		*'--body "$(cat "$'*) continue ;;
+		*'--description "$(cat "$'*) continue ;;
+		*'--title "$(cat "$'*) continue ;;
+	esac
+
+	# Check for potentially unsafe inline body/message/description with quotes
+	# that could contain dynamic content (not from a file read)
+	if printf '%s' "$line" | grep -qE '(gh pr (comment|create)|glab mr (comment|note|create)).*(--body|--message|--description)[[:space:]]+"'; then
+		# Record the unsafe command for later reporting
+		printf '%s\n' "$line" >> "$UNSAFE_COMMANDS"
+	fi
+done
+
+if [ -s "$UNSAFE_COMMANDS" ]; then
+	cmd=$(head -n 1 "$UNSAFE_COMMANDS" | sed -E 's/^[[:space:]]*//')
+	rm -f "$UNSAFE_COMMANDS"
+	fail "${PROVIDERS}: found potentially unsafe inline body in command: $cmd"
+fi
+rm -f "$UNSAFE_COMMANDS"
+
 # --- The ledger's primary lookup key (file + title, never raw line number) is
 # the crux of the oscillation guard; it must be stated consistently in both
 # SKILL.md and convergence.md so a future edit can't silently key on line

--- a/tests/qodo-pr-resolver-doc-consistency.sh
+++ b/tests/qodo-pr-resolver-doc-consistency.sh
@@ -46,6 +46,20 @@ done
 grep -Fq '## Qodo Fix Summary — Round N' "${PROVIDERS}" ||
 	fail "${PROVIDERS}: expected the literal posted heading '## Qodo Fix Summary — Round N'"
 
+# --- Dynamic summaries contain verbatim issue titles and user-provided
+# reasons. Keep both CLI examples on file-based input so apostrophes and shell
+# operators in that untrusted text are never parsed as part of a command.
+grep -Fq 'gh pr comment <pr-number> --body-file "$COMMENT_FILE"' "${PROVIDERS}" ||
+	fail "${PROVIDERS}: GitHub summaries must use --body-file"
+grep -Fq 'glab mr comment <mr-iid> < "$COMMENT_FILE"' "${PROVIDERS}" ||
+	fail "${PROVIDERS}: GitLab summaries must read the body from a file"
+if grep -Fq "gh pr comment <pr-number> --body '<comment-body>'" "${PROVIDERS}"; then
+	fail "${PROVIDERS}: unsafe shell-quoted GitHub summary example is present"
+fi
+if grep -Fq "glab mr comment <mr-iid> --message '<comment-body>'" "${PROVIDERS}"; then
+	fail "${PROVIDERS}: unsafe shell-quoted GitLab summary example is present"
+fi
+
 # --- The ledger's primary lookup key (file + title, never raw line number) is
 # the crux of the oscillation guard; it must be stated consistently in both
 # SKILL.md and convergence.md so a future edit can't silently key on line

--- a/tests/qodo-pr-resolver-doc-consistency.sh
+++ b/tests/qodo-pr-resolver-doc-consistency.sh
@@ -84,7 +84,7 @@ grep -E '(gh pr (comment|create)|glab mr (comment|note|create))' "${PROVIDERS}" 
 	# that could contain dynamic content (not from a file read)
 	if printf '%s' "$line" | grep -qE '(gh pr (comment|create)|glab mr (comment|note|create)).*(--body|--message|--description)[[:space:]]+"'; then
 		# Record the unsafe command for later reporting
-		printf '%s\n' "$line" >> "$UNSAFE_COMMANDS"
+		printf '%s\n' "$line" >>"$UNSAFE_COMMANDS"
 	fi
 done
 


### PR DESCRIPTION
### Motivation
- Eliminate a high-risk shell-injection vector when posting Qodo summary comments by avoiding embedding untrusted, verbatim issue titles or user reasons inside shell-quoted arguments or heredocs.

### Description
- Update provider guidance in `.agents/skills/qodo-pr-resolver/resources/providers.md` to use file-based comment bodies (create a `mktemp` file, register cleanup `trap`s, write the rendered body to the file, then pass `--body-file` or stdin to provider CLIs) instead of embedding the body in a quoted shell argument or heredoc.
- Harden Bitbucket/GitLab/GitHub/Azure DevOps examples to demonstrate safe temporary-file use and safer credential/config parsing where applicable.
- Add assertions to `tests/qodo-pr-resolver-doc-consistency.sh` that enforce GitHub examples use `--body-file` and GitLab examples read the comment body from a file, and fail if any unsafe shell-quoted summary examples remain.

### Testing
- Ran `git diff --check` and it reported no whitespace/patch errors.
- Ran `sh -n tests/qodo-pr-resolver-doc-consistency.sh` (syntax check) and it passed.
- Executed `sh tests/qodo-pr-resolver-doc-consistency.sh` and the test printed the expected PASS line indicating the doc-consistency checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a770ff3f3a08329bb17990935ae8387)