### PR TITLE
ci: bound regression test runtimes and harden proc-settings regression

### DIFF
--- a/.github/workflows/code-quality-review.yml
+++ b/.github/workflows/code-quality-review.yml
@@ -20,6 +20,7 @@ jobs:
   local-quality:
     name: Local Code Quality Checks
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     permissions:
       contents: read
@@ -43,11 +44,14 @@ jobs:
           sudo apt-get install -y shellcheck shfmt ripgrep dnsmasq
 
       - name: Run local code quality checks
+        env:
+          TEST_MAX_RUNTIME_SECONDS: 180
         run: sh tools/code-quality.sh
 
   sonarcloud:
     name: SonarCloud Code Analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     permissions:
       contents: read

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -17,6 +17,7 @@ jobs:
   shell-quality:
     name: Shell and checksum quality checks
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
@@ -27,6 +28,9 @@ jobs:
           sudo apt-get install -y shellcheck shfmt ripgrep dnsmasq
 
       - name: Run code quality checks
+        # GNU timeout is CI-only; router production scripts remain independent of it.
+        env:
+          TEST_MAX_RUNTIME_SECONDS: 180
         run: sh tools/code-quality.sh
 
       - name: Explain formatting remediation

--- a/.github/workflows/shell-validation.yml
+++ b/.github/workflows/shell-validation.yml
@@ -15,6 +15,7 @@ jobs:
   posix-syntax:
     name: BusyBox ash syntax
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -53,21 +54,22 @@ jobs:
           dash -n tools/update-checksums.sh
 
       - name: Run mkdir reaper owner publication regression
-        run: busybox ash tests/installer-reaper-owner-publication.sh
+        run: timeout --kill-after=10 180 busybox ash tests/installer-reaper-owner-publication.sh
 
       - name: Run process signaling regression with BusyBox ash
-        run: busybox ash tests/rc-process-signaling.sh
+        run: timeout --kill-after=10 180 busybox ash tests/rc-process-signaling.sh
 
       - name: Run bounded service lifecycle integration matrix
         # DNS handoff validates root-only FIFO ownership, matching router init.
-        run: sudo -n env AGH_INTEGRATION_SHELL=busybox AGH_INTEGRATION_SHELL_ARG=ash busybox ash tests/service-lifecycle-integration.sh
+        run: timeout --kill-after=10 600 sudo -n env AGH_INTEGRATION_SHELL=busybox AGH_INTEGRATION_SHELL_ARG=ash busybox ash tests/service-lifecycle-integration.sh
 
       - name: Run optional database link regression
-        run: sudo -n busybox ash tests/optional-database-links.sh
+        run: timeout --kill-after=10 180 sudo -n busybox ash tests/optional-database-links.sh
 
   shellcheck:
     name: ShellCheck POSIX ash profile
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -99,6 +101,7 @@ jobs:
   checksums:
     name: Checksum validation
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Pull request runs can start before the separate checksum updater workflow
     # has pushed its chore commit. This job waits for that branch update and
     # validates the latest PR head. Non-bot push runs are skipped so they do not
@@ -183,6 +186,7 @@ jobs:
   shfmt:
     name: shfmt mksh recommendations
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/shell-validation.yml
+++ b/.github/workflows/shell-validation.yml
@@ -61,10 +61,10 @@ jobs:
 
       - name: Run bounded service lifecycle integration matrix
         # DNS handoff validates root-only FIFO ownership, matching router init.
-        run: timeout --kill-after=10 600 sudo -n env AGH_INTEGRATION_SHELL=busybox AGH_INTEGRATION_SHELL_ARG=ash busybox ash tests/service-lifecycle-integration.sh
+        run: sudo -n timeout --kill-after=10 600 env AGH_INTEGRATION_SHELL=busybox AGH_INTEGRATION_SHELL_ARG=ash busybox ash tests/service-lifecycle-integration.sh
 
       - name: Run optional database link regression
-        run: timeout --kill-after=10 180 sudo -n busybox ash tests/optional-database-links.sh
+        run: sudo -n timeout --kill-after=10 180 busybox ash tests/optional-database-links.sh
 
   shellcheck:
     name: ShellCheck POSIX ash profile

--- a/tests/adguardhome-proc-settings.sh
+++ b/tests/adguardhome-proc-settings.sh
@@ -7,10 +7,22 @@ SCRIPT_PATH="${1:-AdGuardHome.sh}"
 TMP_ROOT="${TMPDIR:-/tmp}/agh-proc-settings.$$"
 FUNCTION_FILE="${TMP_ROOT}/functions"
 LOG_FILE="${TMP_ROOT}/log"
+BACKGROUND_PID=""
+SLEEP_CALLS=0
+
+cleanup() {
+	if [ -n "${BACKGROUND_PID:-}" ] && kill -0 "${BACKGROUND_PID}" 2>/dev/null; then
+		kill "${BACKGROUND_PID}" 2>/dev/null || true
+		wait "${BACKGROUND_PID}" 2>/dev/null || true
+	fi
+	rm -rf "${TMP_ROOT}"
+}
+
+trap cleanup 0
+trap 'cleanup; exit 1' HUP INT TERM
 
 fail() {
 	printf '%s\n' "FAIL: $*" >&2
-	rm -rf "${TMP_ROOT}"
 	exit 1
 }
 
@@ -280,6 +292,10 @@ run_uninstall_test unusable-helper 0 0 unusable && fail 'unusable rollback helpe
 
 # The mkdir fallback serializes complete proc transactions.
 LOCK_EVENTS="${TMP_ROOT}/lock-events"
+sleep() {
+	SLEEP_CALLS=$((SLEEP_CALLS + 1))
+	command sleep 0.01
+}
 lock_holder() {
 	printf '%s\n' first-start >>"${LOCK_EVENTS}"
 	sleep 1
@@ -288,12 +304,29 @@ lock_holder() {
 lock_waiter() { printf '%s\n' second >>"${LOCK_EVENTS}"; }
 proc_lock_run lock_holder &
 lock_pid="$!"
-while [ ! -d "${PROC_LOCK_DIR}" ]; do sleep 1; done
+BACKGROUND_PID="${lock_pid}"
+lock_waits=0
+while [ ! -d "${PROC_LOCK_DIR}" ] && [ "${lock_waits}" -lt 20 ]; do
+	sleep 1
+	lock_waits=$((lock_waits + 1))
+done
+[ -d "${PROC_LOCK_DIR}" ] || fail 'lock holder did not publish its lock within 20 iterations'
 proc_lock_run lock_waiter || fail 'serialized waiter failed'
 wait "${lock_pid}" || fail 'serialized holder failed'
+BACKGROUND_PID=""
+if kill -0 "${lock_pid}" 2>/dev/null; then
+	fail 'serialized holder remained after wait'
+fi
+[ "${lock_waits}" -le 20 ] || fail 'lock publication wait exceeded 20 iterations'
+[ "${SLEEP_CALLS}" -le 20 ] || fail 'lock regression exceeded its documented sleep limit'
 [ "$(sed -n '1p' "${LOCK_EVENTS}")" = first-start ] || fail 'lock holder did not start first'
 [ "$(sed -n '2p' "${LOCK_EVENTS}")" = first-end ] || fail 'lock waiter overlapped holder'
 [ "$(sed -n '3p' "${LOCK_EVENTS}")" = second ] || fail 'lock waiter did not run after holder'
 
-rm -rf "${TMP_ROOT}"
+# Exercise and observe an EXIT cleanup trap independently before this test's
+# own cleanup removes the workspace.
+trap_marker="${TMP_ROOT}/cleanup-trap-ran"
+(trap 'printf "%s\n" ran >"${trap_marker}"' 0; :) || fail 'cleanup trap probe failed'
+[ -f "${trap_marker}" ] || fail 'cleanup trap did not run'
+
 printf '%s\n' 'PASS: proc settings are validated, owned, and restored conservatively'

--- a/tests/adguardhome-proc-settings.sh
+++ b/tests/adguardhome-proc-settings.sh
@@ -326,7 +326,10 @@ fi
 # Exercise and observe an EXIT cleanup trap independently before this test's
 # own cleanup removes the workspace.
 trap_marker="${TMP_ROOT}/cleanup-trap-ran"
-(trap 'printf "%s\n" ran >"${trap_marker}"' 0; :) || fail 'cleanup trap probe failed'
+(
+	trap 'printf "%s\n" ran >"${trap_marker}"' 0
+	:
+) || fail 'cleanup trap probe failed'
 [ -f "${trap_marker}" ] || fail 'cleanup trap did not run'
 
 printf '%s\n' 'PASS: proc settings are validated, owned, and restored conservatively'

--- a/tests/code-quality-checks.sh
+++ b/tests/code-quality-checks.sh
@@ -22,17 +22,39 @@ trap 'rm -rf "${TMP_ROOT}"; exit 1' HUP INT TERM
 
 FUNCTIONS_FILE="${TMP_ROOT}/functions.sh"
 sed -n \
-	'/^cleanup() {$/,/^}$/p; /^have_cmd() {$/,/^}$/p; /^require_cmd() {$/,/^}$/p; /^run_test_command() {$/,/^}$/p; /^run_privileged_test_command() {$/,/^}$/p; /^run_check() {$/,/^}$/p; /^run_optional_database_link_check() {$/,/^}$/p; /^run_writable_path_security_check() {$/,/^}$/p; /^run_script_list_check() {$/,/^}$/p' \
+	'/^cleanup() {$/,/^}$/p; /^have_cmd() {$/,/^}$/p; /^require_cmd() {$/,/^}$/p; /^configure_test_timeout() {$/,/^}$/p; /^run_test_command() {$/,/^}$/p; /^run_privileged_test_command() {$/,/^}$/p; /^run_check() {$/,/^}$/p; /^run_optional_database_link_check() {$/,/^}$/p; /^run_writable_path_security_check() {$/,/^}$/p; /^run_script_list_check() {$/,/^}$/p' \
 	"${SCRIPT_PATH}" >"${FUNCTIONS_FILE}"
 [ -s "${FUNCTIONS_FILE}" ] || fail 'function extraction from tools/code-quality.sh was empty (helper functions may have been renamed)'
 
-for fn in cleanup have_cmd require_cmd run_test_command run_privileged_test_command run_check run_optional_database_link_check run_writable_path_security_check run_script_list_check; do
+for fn in cleanup have_cmd require_cmd configure_test_timeout run_test_command run_privileged_test_command run_check run_optional_database_link_check run_writable_path_security_check run_script_list_check; do
 	grep -Fq "${fn}() {" "${FUNCTIONS_FILE}" || fail "extracted functions file is missing ${fn}()"
 done
 
 # shellcheck disable=SC1090
 . "${FUNCTIONS_FILE}"
 TEST_MAX_RUNTIME_SECONDS=0
+GNU_TIMEOUT=""
+
+# Only an absolute executable identifying itself as GNU coreutils timeout may
+# enable the GNU-specific --kill-after option.
+GNU_TIMEOUT_FIXTURE="${TMP_ROOT}/timeout"
+cat >"${GNU_TIMEOUT_FIXTURE}" <<'EOF'
+#!/bin/sh
+printf '%s\n' 'timeout (GNU coreutils) 9.1'
+EOF
+chmod 700 "${GNU_TIMEOUT_FIXTURE}" || fail 'could not prepare GNU timeout fixture'
+which() { printf '%s\n' "${GNU_TIMEOUT_FIXTURE}"; }
+TEST_MAX_RUNTIME_SECONDS=180
+configure_test_timeout || fail 'GNU coreutils timeout provider was rejected'
+[ "${GNU_TIMEOUT}" = "${GNU_TIMEOUT_FIXTURE}" ] || fail 'approved GNU timeout path was not retained'
+cat >"${GNU_TIMEOUT_FIXTURE}" <<'EOF'
+#!/bin/sh
+printf '%s\n' 'BusyBox v1.25.1 multi-call binary.'
+EOF
+if configure_test_timeout 2>/dev/null; then
+	fail 'BusyBox timeout provider was accepted for GNU options'
+fi
+unset -f which 2>/dev/null || unset which 2>/dev/null || true
 
 # A bounded privileged regression must launch timeout as root so it can signal
 # every root-owned descendant, while an unbounded local run invokes the test
@@ -42,8 +64,9 @@ sudo() {
 	printf '%s\n' "$*" >"${PRIVILEGED_ARGS_FILE}"
 }
 TEST_MAX_RUNTIME_SECONDS=180
+GNU_TIMEOUT=/usr/bin/timeout
 run_privileged_test_command sh tests/optional-database-links.sh || fail 'bounded privileged command failed'
-[ "$(cat "${PRIVILEGED_ARGS_FILE}")" = '-n timeout --kill-after=10 180 sh tests/optional-database-links.sh' ] ||
+[ "$(cat "${PRIVILEGED_ARGS_FILE}")" = '-n /usr/bin/timeout --kill-after=10 180 sh tests/optional-database-links.sh' ] ||
 	fail 'bounded timeout was not placed inside sudo'
 TEST_MAX_RUNTIME_SECONDS=0
 run_privileged_test_command sh tests/optional-database-links.sh || fail 'unbounded privileged command failed'

--- a/tests/code-quality-checks.sh
+++ b/tests/code-quality-checks.sh
@@ -22,16 +22,17 @@ trap 'rm -rf "${TMP_ROOT}"; exit 1' HUP INT TERM
 
 FUNCTIONS_FILE="${TMP_ROOT}/functions.sh"
 sed -n \
-	'/^cleanup() {$/,/^}$/p; /^have_cmd() {$/,/^}$/p; /^require_cmd() {$/,/^}$/p; /^run_check() {$/,/^}$/p; /^run_optional_database_link_check() {$/,/^}$/p; /^run_writable_path_security_check() {$/,/^}$/p; /^run_script_list_check() {$/,/^}$/p' \
+	'/^cleanup() {$/,/^}$/p; /^have_cmd() {$/,/^}$/p; /^require_cmd() {$/,/^}$/p; /^run_test_command() {$/,/^}$/p; /^run_check() {$/,/^}$/p; /^run_optional_database_link_check() {$/,/^}$/p; /^run_writable_path_security_check() {$/,/^}$/p; /^run_script_list_check() {$/,/^}$/p' \
 	"${SCRIPT_PATH}" >"${FUNCTIONS_FILE}"
 [ -s "${FUNCTIONS_FILE}" ] || fail 'function extraction from tools/code-quality.sh was empty (helper functions may have been renamed)'
 
-for fn in cleanup have_cmd require_cmd run_check run_optional_database_link_check run_writable_path_security_check run_script_list_check; do
+for fn in cleanup have_cmd require_cmd run_test_command run_check run_optional_database_link_check run_writable_path_security_check run_script_list_check; do
 	grep -Fq "${fn}() {" "${FUNCTIONS_FILE}" || fail "extracted functions file is missing ${fn}()"
 done
 
 # shellcheck disable=SC1090
 . "${FUNCTIONS_FILE}"
+TEST_MAX_RUNTIME_SECONDS=0
 
 # The writable-path and optional database-link regressions validate root-owned
 # state.  Verify the runner executes both directly as root so the database

--- a/tests/code-quality-checks.sh
+++ b/tests/code-quality-checks.sh
@@ -22,17 +22,34 @@ trap 'rm -rf "${TMP_ROOT}"; exit 1' HUP INT TERM
 
 FUNCTIONS_FILE="${TMP_ROOT}/functions.sh"
 sed -n \
-	'/^cleanup() {$/,/^}$/p; /^have_cmd() {$/,/^}$/p; /^require_cmd() {$/,/^}$/p; /^run_test_command() {$/,/^}$/p; /^run_check() {$/,/^}$/p; /^run_optional_database_link_check() {$/,/^}$/p; /^run_writable_path_security_check() {$/,/^}$/p; /^run_script_list_check() {$/,/^}$/p' \
+	'/^cleanup() {$/,/^}$/p; /^have_cmd() {$/,/^}$/p; /^require_cmd() {$/,/^}$/p; /^run_test_command() {$/,/^}$/p; /^run_privileged_test_command() {$/,/^}$/p; /^run_check() {$/,/^}$/p; /^run_optional_database_link_check() {$/,/^}$/p; /^run_writable_path_security_check() {$/,/^}$/p; /^run_script_list_check() {$/,/^}$/p' \
 	"${SCRIPT_PATH}" >"${FUNCTIONS_FILE}"
 [ -s "${FUNCTIONS_FILE}" ] || fail 'function extraction from tools/code-quality.sh was empty (helper functions may have been renamed)'
 
-for fn in cleanup have_cmd require_cmd run_test_command run_check run_optional_database_link_check run_writable_path_security_check run_script_list_check; do
+for fn in cleanup have_cmd require_cmd run_test_command run_privileged_test_command run_check run_optional_database_link_check run_writable_path_security_check run_script_list_check; do
 	grep -Fq "${fn}() {" "${FUNCTIONS_FILE}" || fail "extracted functions file is missing ${fn}()"
 done
 
 # shellcheck disable=SC1090
 . "${FUNCTIONS_FILE}"
 TEST_MAX_RUNTIME_SECONDS=0
+
+# A bounded privileged regression must launch timeout as root so it can signal
+# every root-owned descendant, while an unbounded local run invokes the test
+# directly through sudo.
+PRIVILEGED_ARGS_FILE="${TMP_ROOT}/privileged-args"
+sudo() {
+	printf '%s\n' "$*" >"${PRIVILEGED_ARGS_FILE}"
+}
+TEST_MAX_RUNTIME_SECONDS=180
+run_privileged_test_command sh tests/optional-database-links.sh || fail 'bounded privileged command failed'
+[ "$(cat "${PRIVILEGED_ARGS_FILE}")" = '-n timeout --kill-after=10 180 sh tests/optional-database-links.sh' ] ||
+	fail 'bounded timeout was not placed inside sudo'
+TEST_MAX_RUNTIME_SECONDS=0
+run_privileged_test_command sh tests/optional-database-links.sh || fail 'unbounded privileged command failed'
+[ "$(cat "${PRIVILEGED_ARGS_FILE}")" = '-n sh tests/optional-database-links.sh' ] ||
+	fail 'unbounded privileged command did not retain direct sudo ordering'
+unset -f sudo 2>/dev/null || unset sudo 2>/dev/null || true
 
 # The writable-path and optional database-link regressions validate root-owned
 # state.  Verify the runner executes both directly as root so the database

--- a/tests/shellcheck-workflow-dialect-consistency.sh
+++ b/tests/shellcheck-workflow-dialect-consistency.sh
@@ -86,8 +86,8 @@ CHECKSUM_BASE='checksum_targets=(installer AdGuardHome.sh S99AdGuardHome rc.func
 	fail "${WORKFLOW}: expected the identical base checksum_targets declaration in both the wait-for-chore-commit and validate steps"
 grep -Fq 'tools/check-md5.sh' "${WORKFLOW}" || fail "${WORKFLOW}: checksums job is missing tools/check-md5.sh"
 grep -Fq 'tools/check-sha256.sh' "${WORKFLOW}" || fail "${WORKFLOW}: checksums job is missing tools/check-sha256.sh"
-grep -Fq 'run: busybox ash tests/rc-process-signaling.sh' "${WORKFLOW}" ||
-	fail "${WORKFLOW}: POSIX syntax job does not run the process signaling regression with BusyBox ash"
+grep -Fq 'run: timeout --kill-after=10 180 busybox ash tests/rc-process-signaling.sh' "${WORKFLOW}" ||
+	fail "${WORKFLOW}: POSIX syntax job does not run a bounded process signaling regression with BusyBox ash"
 grep -Fq 'tools/update-checksums.sh' "${WORKFLOW}" || fail "${WORKFLOW}: checksums job is missing tools/update-checksums.sh"
 grep -Fq 'busybox ash tests/checksum-file-format.sh' "${WORKFLOW}" ||
 	fail "${WORKFLOW}: checksums job is missing the checksum file-format regression"

--- a/tests/shellcheck-workflow-dialect-consistency.sh
+++ b/tests/shellcheck-workflow-dialect-consistency.sh
@@ -88,6 +88,13 @@ grep -Fq 'tools/check-md5.sh' "${WORKFLOW}" || fail "${WORKFLOW}: checksums job 
 grep -Fq 'tools/check-sha256.sh' "${WORKFLOW}" || fail "${WORKFLOW}: checksums job is missing tools/check-sha256.sh"
 grep -Fq 'run: timeout --kill-after=10 180 busybox ash tests/rc-process-signaling.sh' "${WORKFLOW}" ||
 	fail "${WORKFLOW}: POSIX syntax job does not run a bounded process signaling regression with BusyBox ash"
+grep -Fq 'run: sudo -n timeout --kill-after=10 600 env AGH_INTEGRATION_SHELL=busybox' "${WORKFLOW}" ||
+	fail "${WORKFLOW}: lifecycle timeout must run inside sudo"
+grep -Fq 'run: sudo -n timeout --kill-after=10 180 busybox ash tests/optional-database-links.sh' "${WORKFLOW}" ||
+	fail "${WORKFLOW}: optional database timeout must run inside sudo"
+if grep -Eq 'run: timeout .*sudo -n' "${WORKFLOW}"; then
+	fail "${WORKFLOW}: privileged regression timeout runs outside sudo"
+fi
 grep -Fq 'tools/update-checksums.sh' "${WORKFLOW}" || fail "${WORKFLOW}: checksums job is missing tools/update-checksums.sh"
 grep -Fq 'busybox ash tests/checksum-file-format.sh' "${WORKFLOW}" ||
 	fail "${WORKFLOW}: checksums job is missing the checksum file-format regression"

--- a/tools/code-quality.sh
+++ b/tools/code-quality.sh
@@ -8,6 +8,7 @@ set -u
 FAILED=0
 FIX=0
 SCRIPT_LIST=""
+TEST_MAX_RUNTIME_SECONDS="${TEST_MAX_RUNTIME_SECONDS:-0}"
 
 case "${1:-}" in
 	--fix) FIX=1 ;;
@@ -54,12 +55,32 @@ require_cmd() {
 	return 1
 }
 
+# run_test_command optionally bounds a CI test command with GNU timeout. Router
+# runs leave TEST_MAX_RUNTIME_SECONDS unset and do not depend on timeout(1).
+run_test_command() {
+	if [ "${TEST_MAX_RUNTIME_SECONDS}" -gt 0 ]; then
+		timeout --kill-after=10 "${TEST_MAX_RUNTIME_SECONDS}" "$@"
+		return
+	fi
+	"$@"
+}
+
 # run_check runs a named check, reports its result, and marks the overall run as failed when the check fails.
 run_check() {
 	_name="$1"
 	shift
 	printf '%s\n' "==> ${_name}"
-	if "$@"; then
+	case "${1:-}" in
+		run_dns_handoff_check | run_optional_database_link_check | run_writable_path_security_check)
+			"$@"
+			_check_status=$?
+			;;
+		*)
+			run_test_command "$@"
+			_check_status=$?
+			;;
+	esac
+	if [ "${_check_status}" -eq 0 ]; then
 		printf '%s\n' "OK: ${_name}"
 	else
 		printf '%s\n' "FAILED: ${_name}" >&2
@@ -70,12 +91,12 @@ run_check() {
 # run_dns_handoff_check runs the DNS startup handoff regression test with root privileges or passwordless sudo.
 run_dns_handoff_check() {
 	if [ "$(id -u)" -eq 0 ]; then
-		sh tests/dns-startup-handoff.sh
+		run_test_command sh tests/dns-startup-handoff.sh
 		return
 	fi
 
 	if have_cmd sudo && sudo -n true >/dev/null 2>&1; then
-		sudo -n sh tests/dns-startup-handoff.sh
+		run_test_command sudo -n sh tests/dns-startup-handoff.sh
 		return
 	fi
 
@@ -86,12 +107,12 @@ run_dns_handoff_check() {
 # run_optional_database_link_check runs the optional database link regression as root or through passwordless sudo.
 run_optional_database_link_check() {
 	if [ "$(id -u)" -eq 0 ]; then
-		sh tests/optional-database-links.sh
+		run_test_command sh tests/optional-database-links.sh
 		return
 	fi
 
 	if have_cmd sudo && sudo -n true >/dev/null 2>&1; then
-		sudo -n sh tests/optional-database-links.sh
+		run_test_command sudo -n sh tests/optional-database-links.sh
 		return
 	fi
 
@@ -102,12 +123,12 @@ run_optional_database_link_check() {
 # run_writable_path_security_check runs the runtime writable-path security regression as root or through passwordless sudo.
 run_writable_path_security_check() {
 	if [ "$(id -u)" -eq 0 ]; then
-		sh tests/runtime-writable-path-security.sh
+		run_test_command sh tests/runtime-writable-path-security.sh
 		return
 	fi
 
 	if have_cmd sudo && sudo -n true >/dev/null 2>&1; then
-		sudo -n sh tests/runtime-writable-path-security.sh
+		run_test_command sudo -n sh tests/runtime-writable-path-security.sh
 		return
 	fi
 
@@ -141,6 +162,17 @@ run_script_list_check() {
 
 trap cleanup 0
 trap 'cleanup; exit 1' HUP INT TERM
+
+case "${TEST_MAX_RUNTIME_SECONDS}" in
+	'' | *[!0-9]*)
+		printf '%s\n' 'Error: TEST_MAX_RUNTIME_SECONDS must be a non-negative integer.' >&2
+		exit 2
+		;;
+esac
+if [ "${TEST_MAX_RUNTIME_SECONDS}" -gt 0 ] && ! have_cmd timeout; then
+	printf '%s\n' 'Error: timeout is required when TEST_MAX_RUNTIME_SECONDS is set.' >&2
+	exit 2
+fi
 
 SCRIPT_LIST="${TMPDIR:-/tmp}/code-quality-scripts.$$"
 if ! sh tools/list-shell-scripts.sh >"${SCRIPT_LIST}"; then

--- a/tools/code-quality.sh
+++ b/tools/code-quality.sh
@@ -65,6 +65,17 @@ run_test_command() {
 	"$@"
 }
 
+# run_privileged_test_command places the optional CI timeout inside sudo so it
+# can signal the complete root-owned process group. Unbounded local runs retain
+# the direct sudo invocation.
+run_privileged_test_command() {
+	if [ "${TEST_MAX_RUNTIME_SECONDS}" -gt 0 ]; then
+		sudo -n timeout --kill-after=10 "${TEST_MAX_RUNTIME_SECONDS}" "$@"
+		return
+	fi
+	sudo -n "$@"
+}
+
 # run_check runs a named check, reports its result, and marks the overall run as failed when the check fails.
 run_check() {
 	_name="$1"
@@ -96,7 +107,7 @@ run_dns_handoff_check() {
 	fi
 
 	if have_cmd sudo && sudo -n true >/dev/null 2>&1; then
-		run_test_command sudo -n sh tests/dns-startup-handoff.sh
+		run_privileged_test_command sh tests/dns-startup-handoff.sh
 		return
 	fi
 
@@ -112,7 +123,7 @@ run_optional_database_link_check() {
 	fi
 
 	if have_cmd sudo && sudo -n true >/dev/null 2>&1; then
-		run_test_command sudo -n sh tests/optional-database-links.sh
+		run_privileged_test_command sh tests/optional-database-links.sh
 		return
 	fi
 
@@ -128,7 +139,7 @@ run_writable_path_security_check() {
 	fi
 
 	if have_cmd sudo && sudo -n true >/dev/null 2>&1; then
-		run_test_command sudo -n sh tests/runtime-writable-path-security.sh
+		run_privileged_test_command sh tests/runtime-writable-path-security.sh
 		return
 	fi
 

--- a/tools/code-quality.sh
+++ b/tools/code-quality.sh
@@ -9,6 +9,7 @@ FAILED=0
 FIX=0
 SCRIPT_LIST=""
 TEST_MAX_RUNTIME_SECONDS="${TEST_MAX_RUNTIME_SECONDS:-0}"
+GNU_TIMEOUT=""
 
 case "${1:-}" in
 	--fix) FIX=1 ;;
@@ -55,11 +56,33 @@ require_cmd() {
 	return 1
 }
 
+# configure_test_timeout resolves and approves GNU coreutils timeout for CI.
+# Production/router runs leave the runtime limit at zero and skip this probe.
+configure_test_timeout() {
+	[ "${TEST_MAX_RUNTIME_SECONDS}" -gt 0 ] || return 0
+	GNU_TIMEOUT=$(which timeout 2>/dev/null) || GNU_TIMEOUT=""
+	case "${GNU_TIMEOUT}" in
+		/*) ;;
+		*) GNU_TIMEOUT="" ;;
+	esac
+	if [ -z "${GNU_TIMEOUT}" ] || [ ! -x "${GNU_TIMEOUT}" ]; then
+		printf '%s\n' 'Error: GNU coreutils timeout is required when TEST_MAX_RUNTIME_SECONDS is set.' >&2
+		return 1
+	fi
+	_timeout_version=$("${GNU_TIMEOUT}" --version 2>/dev/null) || _timeout_version=""
+	case "${_timeout_version}" in
+		timeout\ \(GNU\ coreutils\)*) return 0 ;;
+	esac
+	GNU_TIMEOUT=""
+	printf '%s\n' 'Error: PATH timeout is not the required GNU coreutils implementation.' >&2
+	return 1
+}
+
 # run_test_command optionally bounds a CI test command with GNU timeout. Router
 # runs leave TEST_MAX_RUNTIME_SECONDS unset and do not depend on timeout(1).
 run_test_command() {
 	if [ "${TEST_MAX_RUNTIME_SECONDS}" -gt 0 ]; then
-		timeout --kill-after=10 "${TEST_MAX_RUNTIME_SECONDS}" "$@"
+		"${GNU_TIMEOUT}" --kill-after=10 "${TEST_MAX_RUNTIME_SECONDS}" "$@"
 		return
 	fi
 	"$@"
@@ -70,7 +93,7 @@ run_test_command() {
 # the direct sudo invocation.
 run_privileged_test_command() {
 	if [ "${TEST_MAX_RUNTIME_SECONDS}" -gt 0 ]; then
-		sudo -n timeout --kill-after=10 "${TEST_MAX_RUNTIME_SECONDS}" "$@"
+		sudo -n "${GNU_TIMEOUT}" --kill-after=10 "${TEST_MAX_RUNTIME_SECONDS}" "$@"
 		return
 	fi
 	sudo -n "$@"
@@ -180,8 +203,7 @@ case "${TEST_MAX_RUNTIME_SECONDS}" in
 		exit 2
 		;;
 esac
-if [ "${TEST_MAX_RUNTIME_SECONDS}" -gt 0 ] && ! have_cmd timeout; then
-	printf '%s\n' 'Error: timeout is required when TEST_MAX_RUNTIME_SECONDS is set.' >&2
+if ! configure_test_timeout; then
 	exit 2
 fi
 


### PR DESCRIPTION
### Motivation

- Ensure CI regression scripts and logical test groups cannot run indefinitely by enforcing per-test and job-level runtime bounds without introducing `timeout` into production router scripts.
- Make bounded execution observable in the quality runner so CI failures surface reliably to review workflows and cannot be masked by a best-effort wrapper.
- Improve the proc-settings concurrency regression to reliably reap background children, limit polling/sleep iterations, and verify cleanup traps run so tests fail fast on leaks.

### Description

- Add a CI-only runtime cap `TEST_MAX_RUNTIME_SECONDS` and a `run_test_command` wrapper to `tools/code-quality.sh` that uses GNU `timeout --kill-after=10` when the variable is set, and validate the variable and presence of `timeout` when used. (`tools/code-quality.sh`)
- Update `run_check` and privileged-run helpers to invoke tests through `run_test_command` while keeping router-side scripts independent of `timeout`. (`tools/code-quality.sh`)
- Set `TEST_MAX_RUNTIME_SECONDS=180` via `env:` in the blocking and review workflows and add job-level `timeout-minutes` for relevant workflow jobs. (`.github/workflows/code-quality.yml`, `.github/workflows/code-quality-review.yml`)
- Add explicit `timeout --kill-after=...` bounds to BusyBox regression steps (reaper, process signaling, optional DB link) and a longer bounded run for the lifecycle integration matrix. (`.github/workflows/shell-validation.yml`)
- Harden `tests/adguardhome-proc-settings.sh` to track and reap the background lock-holder, count and bound sleep/poll iterations, shorten sleeps for CI, assert the holder exited after `wait`, and verify an `EXIT` cleanup trap ran. (`tests/adguardhome-proc-settings.sh`)
- Update CI/contract tests to extract and validate the new `run_test_command` function and to expect the bounded invocations in workflows. (`tests/code-quality-checks.sh`, `tests/shellcheck-workflow-dialect-consistency.sh`)

### Testing

- Ran syntax and targeted execution checks: `sh -n tools/code-quality.sh tests/adguardhome-proc-settings.sh tests/code-quality-checks.sh tests/shellcheck-workflow-dialect-consistency.sh` (passed).
- Executed selected regressions and contract tests locally: `sh tests/adguardhome-proc-settings.sh`, `sh tests/coderabbit-and-workflow-config-checks.sh`, `sh tests/code-quality-checks.sh`, and `sh tests/shellcheck-workflow-dialect-consistency.sh` (all passed in the local environment used for this change).
- Verified repository hygiene: `git diff --check` and workflow/working-tree validations completed without errors.
- Note: `shellcheck` was not installed in the local environment used to prepare this PR, so `shellcheck -s sh ...` was not run locally though CI installs and runs `shellcheck` during workflow execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a83aed1028c832981151bed06cecf51)