### PR TITLE
Add targeted BusyBox/POSIX review checks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -88,6 +88,29 @@ reviews:
       instructions: |
         Treat the repository's AGENTS.md as the primary engineering standard.
 
+        For every changed shell file recognized by tools/list-shell-scripts.sh,
+        including extensionless `installer`, `S99AdGuardHome`, and
+        `rc.func.AdGuardHome`, apply these targeted runtime checks:
+        - Exact introductions of `set -o pipefail`, `${var//...}`, `<<<`,
+          `<(...)`, `>(...)`, `read -a`, `readarray`, or `mapfile`; distinguish
+          these from POSIX command substitution, prefix/suffix removal, and
+          non-executable examples.
+        - GNU-only `sed`, `find`, `xargs`, `date`, or `grep` flags, checked
+          against BusyBox v1.25.1 rather than rejected by command name; exempt
+          tooling that explicitly selects a host GNU binary.
+        - `local NAME="$(command)"` only when later control flow needs the
+          command's status; recommend a separate declaration and assignment.
+        - Sleep operands outside the repository-supported integer-seconds forms
+          (`sleep N` and `sleep Ns`); do not flag the established `Ns` suffix.
+        - Unqualified privileged/security-sensitive commands only where an unsafe
+          or attacker-influenced PATH can change resolution. Do not require absolute
+          paths under the documented stock-first PATH.
+        - New runtime dependencies on Python, Perl, `realpath`, or `timeout`,
+          excluding established provisioned Entware flows and explicit CI-only
+          GNU tooling.
+        - New unconditional `flock` acquisition; accept calls reached only
+          after availability/capability probes with the existing fallback intact.
+
         Keep reviews high-signal:
         - Report only likely correctness, security, compatibility, state-safety,
           reliability, or meaningful performance defects.
@@ -99,6 +122,8 @@ reviews:
         - Explain the practical effect on installation, upgrade, service
           operation, recovery, or router state.
         - Prefer a minimal fix over a broad refactor.
+        - When a checksum-covered runtime artifact changes, verify both its
+          `.md5sum` and `.sha256sum` sidecars are updated.
         - Do not duplicate findings already reported by CI unless the CI result
           reveals a distinct root cause.
         - Do not claim a theoretical issue without identifying a reachable
@@ -111,17 +136,6 @@ reviews:
 
         Check especially for:
         - Bash-only syntax or GNU-only command options.
-        - Exact introductions of `set -o pipefail`, `${var//...}`, `<<<`,
-          `<(...)`, `>(...)`, `read -a`, `readarray`, or `mapfile`; distinguish
-          these from POSIX command substitution, prefix/suffix removal, and
-          non-executable examples.
-        - GNU-only `sed`, `find`, `xargs`, `date`, or `grep` flags in router
-          runtime lines, checked against BusyBox v1.25.1 rather than rejected by
-          command name; exempt tooling that explicitly selects a host GNU binary.
-        - `local NAME="$(command)"` only when later control flow needs the
-          command's status; recommend a separate declaration and assignment.
-        - Suffixed runtime `sleep` operands unless support is established for
-          the target BusyBox build; prefer validated integer seconds.
         - Incorrect quoting, word splitting, globbing, IFS handling, or unsafe
           use of user-controlled input.
         - set -u failures from unset variables.
@@ -137,15 +151,7 @@ reviews:
         - Unbounded waits, retry loops, process leaks, stale PIDs, PID reuse,
           and excessive process creation on constrained router hardware.
         - Router-stock PATH precedence over Entware paths.
-        - Unqualified privileged/security-sensitive commands only where an unsafe
-          or attacker-influenced PATH can change resolution. Do not require absolute
-          paths under the documented stock-first PATH.
         - Use of commands that are unavailable on the target router.
-        - New runtime dependencies on Python, Perl, `realpath`, or `timeout`,
-          excluding established provisioned Entware flows and explicit CI-only
-          GNU tooling.
-        - New unconditional `flock` acquisition; accept calls reached only
-          after availability/capability probes with the existing fallback intact.
         - BusyBox applet behavior that differs from GNU implementations.
 
         Do not flag use of local solely because it is not strictly POSIX.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -111,6 +111,17 @@ reviews:
 
         Check especially for:
         - Bash-only syntax or GNU-only command options.
+        - Exact introductions of `set -o pipefail`, `${var//...}`, `<<<`,
+          `<(...)`, `>(...)`, `read -a`, `readarray`, or `mapfile`; distinguish
+          these from POSIX command substitution, prefix/suffix removal, and
+          non-executable examples.
+        - GNU-only `sed`, `find`, `xargs`, `date`, or `grep` flags in router
+          runtime lines, checked against BusyBox v1.25.1 rather than rejected by
+          command name; exempt tooling that explicitly selects a host GNU binary.
+        - `local NAME="$(command)"` only when later control flow needs the
+          command's status; recommend a separate declaration and assignment.
+        - Suffixed runtime `sleep` operands unless support is established for
+          the target BusyBox build; prefer validated integer seconds.
         - Incorrect quoting, word splitting, globbing, IFS handling, or unsafe
           use of user-controlled input.
         - set -u failures from unset variables.
@@ -126,7 +137,15 @@ reviews:
         - Unbounded waits, retry loops, process leaks, stale PIDs, PID reuse,
           and excessive process creation on constrained router hardware.
         - Router-stock PATH precedence over Entware paths.
+        - Unqualified privileged/security-sensitive commands only where an unsafe
+          or attacker-influenced PATH can change resolution. Do not require absolute
+          paths under the documented stock-first PATH.
         - Use of commands that are unavailable on the target router.
+        - New runtime dependencies on Python, Perl, `realpath`, or `timeout`,
+          excluding established provisioned Entware flows and explicit CI-only
+          GNU tooling.
+        - New unconditional `flock` acquisition; accept calls reached only
+          after availability/capability probes with the existing fallback intact.
         - BusyBox applet behavior that differs from GNU implementations.
 
         Do not flag use of local solely because it is not strictly POSIX.
@@ -361,4 +380,3 @@ knowledge_base:
 
   pull_requests:
     scope: "local"
-

--- a/.github/prompts/codex-code-improvement.md
+++ b/.github/prompts/codex-code-improvement.md
@@ -10,12 +10,15 @@ Review scope:
 - Call out bugs, unsafe shell expansions, BusyBox/POSIX ash portability regressions, checksum drift, and missing validation.
 - Target changed executable lines for `set -o pipefail`, `${var//...}`,
   here-strings/process substitution, array-reading builtins, status-masking
-  `local NAME="$(command)"`, unverified sleep suffixes, and GNU-only runtime
-  flags; do not match comments, fixtures, or similar POSIX constructs.
+  `local NAME="$(command)"`, unsupported sleep operands, and GNU-only runtime
+  flags in every inventory-listed shell file, including extensionless runtime
+  scripts; do not match comments, fixtures, similar POSIX constructs, or the
+  repository-supported integer forms `sleep N` and `sleep Ns`.
 - Flag unsafe command resolution, unconditional `flock`, and new Python, Perl,
   `realpath`, or `timeout` runtime dependencies only when the changed execution
   path actually introduces that requirement.
-- Check whether changed installer/service artifacts need matching `.md5sum` updates.
+- Check whether changed installer/service artifacts need matching `.md5sum` and
+  `.sha256sum` updates.
 - Consider whether changes remain compatible with constrained router environments.
 
 Useful local checks:

--- a/.github/prompts/codex-code-improvement.md
+++ b/.github/prompts/codex-code-improvement.md
@@ -8,6 +8,13 @@ Review scope:
 - Review only the changes introduced by this pull request.
 - Prefer actionable findings over broad style comments.
 - Call out bugs, unsafe shell expansions, BusyBox/POSIX ash portability regressions, checksum drift, and missing validation.
+- Target changed executable lines for `set -o pipefail`, `${var//...}`,
+  here-strings/process substitution, array-reading builtins, status-masking
+  `local NAME="$(command)"`, unverified sleep suffixes, and GNU-only runtime
+  flags; do not match comments, fixtures, or similar POSIX constructs.
+- Flag unsafe command resolution, unconditional `flock`, and new Python, Perl,
+  `realpath`, or `timeout` runtime dependencies only when the changed execution
+  path actually introduces that requirement.
 - Check whether changed installer/service artifacts need matching `.md5sum` updates.
 - Consider whether changes remain compatible with constrained router environments.
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -167,10 +167,11 @@ long options and to `sed -E`/`-z`, `find -printf`/`-regextype`, `xargs -d`,
 portable options merely because GNU also implements them. Exclude host-only CI
 and test tooling when it explicitly selects a GNU binary.
 
-Do not introduce suffixed `sleep` operands in router runtime code. Unless the
-specific BusyBox v1.25.1 build capability is established, use validated integer
-seconds (for example, `sleep 1`, not `sleep 1s`); do not flag prose, mocks, or
-test assertions that merely mention a suffixed invocation.
+The supported firmware and existing runtime convention accept integer seconds
+as either `sleep N` or `sleep Ns`. Do not flag the established `Ns` suffix.
+Review newly introduced fractional operands or other suffixes only when their
+support on BusyBox v1.25.1 is not established; ignore prose, mocks, and test
+assertions that merely mention a sleep invocation.
 
 Do not assume an applet listed above supports every option provided by its GNU counterpart.
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -94,6 +94,14 @@ Flag newly introduced use of:
 * Bash-specific function syntax
 * Other syntax requiring `/bin/bash`
 
+Keep these checks syntax-aware and limited to executable changed lines. In
+particular, do not confuse ordinary `$(...)` command substitution with process
+substitution, `${value#prefix}` with `${value//old/new}`, or examples in quoted
+test fixtures and documentation with code that runs on the router. Explicitly
+check for `set -o pipefail`, `<<<`, `<(...)`, `>(...)`, `read -a`, `readarray`,
+and `mapfile`; these constructs can otherwise look plausible while still
+failing under the target `ash`.
+
 Compatible patterns include:
 
 * `[ ... ]`
@@ -117,6 +125,12 @@ Review changed shell code for:
 * Tests that become invalid when a variable is empty.
 * Incorrect operator precedence in combined `[ ... ]` expressions.
 * Commands whose exit status is hidden or discarded unexpectedly.
+
+When a changed command substitution's status controls the next action, flag
+`local NAME="$(command)"`: BusyBox `ash` reports the status of `local` rather
+than reliably preserving the substitution's status. The targeted correction is
+to declare the local first and assign it in a separate command. Do not flag a
+combined declaration when the substitution status is intentionally ignored.
 
 Do not request unquoted expansion merely to shorten code.
 
@@ -145,6 +159,18 @@ uptime usleep vi watch wc which xargs zcat
 ```
 
 Flag GNU-only options unless support for the target BusyBox version or a required Entware package is established.
+
+For router runtime changes, inspect `sed`, `find`, `xargs`, `date`, and `grep`
+options individually against BusyBox v1.25.1. Pay particular attention to GNU
+long options and to `sed -E`/`-z`, `find -printf`/`-regextype`, `xargs -d`,
+`date -I`/`--iso-8601`, and `grep -P`/`--include`/`--exclude`; do not flag
+portable options merely because GNU also implements them. Exclude host-only CI
+and test tooling when it explicitly selects a GNU binary.
+
+Do not introduce suffixed `sleep` operands in router runtime code. Unless the
+specific BusyBox v1.25.1 build capability is established, use validated integer
+seconds (for example, `sleep 1`, not `sleep 1s`); do not flag prose, mocks, or
+test assertions that merely mention a suffixed invocation.
 
 Do not assume an applet listed above supports every option provided by its GNU counterpart.
 
@@ -199,6 +225,11 @@ Do not assume the following commands are available from the stock router environ
 
 `python3` is acceptable only in an established Entware flow that installs or verifies the required package.
 
+Flag new router-runtime dependencies on `python`, `python3`, `perl`, `realpath`,
+or `timeout` unless the same execution path explicitly provisions and verifies
+an allowed provider. Do not treat comments, diagnostics, test fixtures, or the
+CI-only approved `/usr/bin/timeout` wrapper as runtime dependencies.
+
 Also flag new assumptions involving:
 
 * GNU coreutils behavior
@@ -243,6 +274,13 @@ When changed code requires an absolute router-stock path, review it against thes
 
 Do not automatically require absolute paths when the configured `PATH` safely resolves the intended router-stock command first.
 
+Flag a newly unqualified privileged or security-sensitive command only when its
+resolution can be influenced by an unsafe `PATH` (for example, Entware or a
+writable directory precedes router-stock paths). Prefer restoring the documented
+stock-first `PATH`; require the known absolute path only where resolution itself
+crosses a trust boundary. Do not create noise for ordinary unqualified applets
+under the repository's fixed stock-first `PATH`.
+
 Treat commands such as the following as router-stock or firmware-provided binaries rather than guaranteed BusyBox applets:
 
 * `curl`
@@ -282,6 +320,9 @@ Any changed locking code must preserve:
 * Protection against stale locks and PID reuse where practical.
 
 Flag code that makes `flock` an unconditional requirement or removes a working fallback.
+
+Apply this check only to new or changed lock acquisition paths. A guarded call
+inside an already-probed flock branch is not unconditional use.
 
 ## Filesystem assumptions
 

--- a/tests/coderabbit-and-workflow-config-checks.sh
+++ b/tests/coderabbit-and-workflow-config-checks.sh
@@ -70,6 +70,23 @@ done
 grep -Fq 'path: "installer"' "${CODERABBIT}" || fail "${CODERABBIT}: expected a literal path_instructions entry for \"installer\""
 [ -f 'installer' ] || fail "installer file referenced by ${CODERABBIT} does not exist"
 
+# --- BusyBox review guidance must retain the targeted high-risk constructs
+# without reverting to broad command-name matching that creates noisy findings.
+for expected in \
+	'`set -o pipefail`' \
+	'`${var//...}`' \
+	'`read -a`' \
+	'GNU-only `sed`, `find`, `xargs`, `date`, or `grep` flags' \
+	'`local NAME="$(command)"`' \
+	'Suffixed runtime `sleep` operands' \
+	'attacker-influenced PATH' \
+	'New unconditional `flock` acquisition' \
+	'New runtime dependencies on Python, Perl, `realpath`, or `timeout`'; do
+	grep -Fq "${expected}" "${CODERABBIT}" || fail "${CODERABBIT}: missing targeted review guidance: ${expected}"
+done
+grep -Fq 'Do not require absolute' "${CODERABBIT}" ||
+	fail "${CODERABBIT}: command-path guidance would create noisy absolute-path findings"
+
 # --- Generated checksum artifacts must stay excluded from review, matching
 # the repository's convention that checksums are CI-generated, not authored.
 grep -Fq '"!**/*.md5sum"' "${CODERABBIT}" || fail "${CODERABBIT}: expected path_filters to exclude **/*.md5sum"

--- a/tests/coderabbit-and-workflow-config-checks.sh
+++ b/tests/coderabbit-and-workflow-config-checks.sh
@@ -8,6 +8,7 @@
 set -u
 
 CODERABBIT='.coderabbit.yaml'
+CODEX_PROMPT='.github/prompts/codex-code-improvement.md'
 WORKFLOW='.github/workflows/code-quality.yml'
 REVIEW_WORKFLOW='.github/workflows/code-quality-review.yml'
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/workflow-config-checks.XXXXXX")" || {
@@ -42,7 +43,7 @@ review_checker_is_enforced() {
 	' "${_review_workflow}"
 }
 
-for f in "${CODERABBIT}" "${WORKFLOW}" "${REVIEW_WORKFLOW}"; do
+for f in "${CODERABBIT}" "${CODEX_PROMPT}" "${WORKFLOW}" "${REVIEW_WORKFLOW}"; do
 	[ -f "${f}" ] || fail "expected config file not found: ${f}"
 done
 
@@ -50,7 +51,7 @@ done
 # GitHub Actions both treat tabs as invalid/undefined indentation, and a tab
 # introduced by an editor would not be caught by any shell-focused linter.
 TAB=$(printf '\t')
-for f in "${CODERABBIT}" "${WORKFLOW}" "${REVIEW_WORKFLOW}"; do
+for f in "${CODERABBIT}" "${CODEX_PROMPT}" "${WORKFLOW}" "${REVIEW_WORKFLOW}"; do
 	if grep -Fq "${TAB}" "${f}"; then
 		fail "${f}: contains literal tab character(s); YAML/workflow indentation must use spaces"
 	fi
@@ -70,22 +71,38 @@ done
 grep -Fq 'path: "installer"' "${CODERABBIT}" || fail "${CODERABBIT}: expected a literal path_instructions entry for \"installer\""
 [ -f 'installer' ] || fail "installer file referenced by ${CODERABBIT} does not exist"
 
-# --- BusyBox review guidance must retain the targeted high-risk constructs
-# without reverting to broad command-name matching that creates noisy findings.
+# --- BusyBox review guidance must live in the shared path block so it applies
+# to both *.sh files and every extensionless runtime script in the inventory.
+SHARED_INSTRUCTIONS="${TMP_ROOT}/shared-instructions"
+awk '
+	/^    - path: "\*\*\/\*"$/ { in_shared = 1; next }
+	in_shared && /^    - path:/ { exit }
+	in_shared { print }
+' "${CODERABBIT}" >"${SHARED_INSTRUCTIONS}" || fail "could not extract shared CodeRabbit instructions"
+[ -s "${SHARED_INSTRUCTIONS}" ] || fail "${CODERABBIT}: shared path instructions are empty"
 for expected in \
 	'`set -o pipefail`' \
 	'`${var//...}`' \
 	'`read -a`' \
 	'GNU-only `sed`, `find`, `xargs`, `date`, or `grep` flags' \
 	'`local NAME="$(command)"`' \
-	'Suffixed runtime `sleep` operands' \
+	'`sleep N` and `sleep Ns`' \
 	'attacker-influenced PATH' \
 	'New unconditional `flock` acquisition' \
 	'New runtime dependencies on Python, Perl, `realpath`, or `timeout`'; do
-	grep -Fq "${expected}" "${CODERABBIT}" || fail "${CODERABBIT}: missing targeted review guidance: ${expected}"
+	grep -Fq "${expected}" "${SHARED_INSTRUCTIONS}" || fail "${CODERABBIT}: shared path scope is missing targeted review guidance: ${expected}"
 done
-grep -Fq 'Do not require absolute' "${CODERABBIT}" ||
+for runtime_script in installer S99AdGuardHome rc.func.AdGuardHome; do
+	grep -Fq "\`${runtime_script}\`" "${SHARED_INSTRUCTIONS}" ||
+		fail "${CODERABBIT}: shared shell guidance does not name extensionless runtime script ${runtime_script}"
+done
+grep -Fq 'Do not require absolute' "${SHARED_INSTRUCTIONS}" ||
 	fail "${CODERABBIT}: command-path guidance would create noisy absolute-path findings"
+grep -Fq '`.md5sum` and `.sha256sum` sidecars' "${SHARED_INSTRUCTIONS}" ||
+	fail "${CODERABBIT}: shared review guidance must check both runtime artifact checksum formats"
+if ! grep -Fq '`.md5sum` and' "${CODEX_PROMPT}" || ! grep -Fq '`.sha256sum` updates' "${CODEX_PROMPT}"; then
+	fail "${CODEX_PROMPT}: Codex guidance must check both runtime artifact checksum formats"
+fi
 
 # --- Generated checksum artifacts must stay excluded from review, matching
 # the repository's convention that checksums are CI-generated, not authored.


### PR DESCRIPTION
### Motivation

- Strengthen reviewer guidance to reliably catch BusyBox/ash and POSIX-incompatible constructs that cause real runtime failures without creating noisy false positives. 
- Focus checks on high-risk, syntax-level regressions (pipefail, here-strings, process substitution, Bash-only parameter ops, array-read builtins, GNU-only flags, status-masking, sleep suffixes, PATH resolution, flock and new runtime deps). 

### Description

- Update reviewer guidance in `REVIEW.md` to explicitly check for `set -o pipefail`, here-strings `<<<`, process substitution `<(...)`/`>(...)`, `${var//...}`, `read -a`, `readarray`, `mapfile`, `local NAME="$(command)"` status-masking, suffixed `sleep` usage, and to treat GNU-only `sed`, `find`, `xargs`, `date`, and `grep` flags as BusyBox-sensitive. 
- Update automated-review config in `.coderabbit.yaml` and the Codex prompt in `.github/prompts/codex-code-improvement.md` so automated reviewers target changed executable lines and avoid matching comments/fixtures. 
- Add regression assertions to `tests/coderabbit-and-workflow-config-checks.sh` that verify the targeted guidance remains present and guarded against noisy absolute-path findings. 
- Keep exemptions and scope rules: CI/host-only tooling and established Entware flows are exempted, and guarded/previously-probed `flock` uses are not treated as unconditional failures. 

### Testing

- Ran `git diff --check` which succeeded. 
- Ran syntax and policy checks: `sh -n tests/coderabbit-and-workflow-config-checks.sh`, `sh tests/coderabbit-and-workflow-config-checks.sh`, and `sh tools/check-shell-portability.sh`, all of which passed. 
- Ran the repository quality orchestrator `sh tools/code-quality.sh`, which executed the repository regressions (they passed), but the top-level run produced a nonzero exit due to missing host-side `shellcheck`/`shfmt` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a83e16d06cc8329bd9b9a5c91743838)