### PR TITLE
Validate channel versions across architectures

### DIFF
--- a/tests/release-consistency.sh
+++ b/tests/release-consistency.sh
@@ -49,6 +49,16 @@ VERSION_PATTERN="$(printf '%s\n' "${CURRENT_VERSION}" | sed 's/\./\\./g')"
 
 RELEASE_ROOT="${TMP_ROOT}" sh "${TMP_ROOT}/tools/check-release-consistency.sh" >/dev/null || fail 'valid fixture was rejected'
 
+sed '/[[:space:]]stable[[:space:]]/s/version=v1\.0\.0/version=v1.0.1/' \
+	"${TMP_ROOT}/armv5/checksum.txt" >"${TMP_ROOT}/armv5/checksum.txt.tmp"
+mv "${TMP_ROOT}/armv5/checksum.txt.tmp" "${TMP_ROOT}/armv5/checksum.txt"
+if RELEASE_ROOT="${TMP_ROOT}" sh "${TMP_ROOT}/tools/check-release-consistency.sh" >"${TMP_ROOT}/version-mismatch.out" 2>&1; then
+	fail 'architecture-specific stable version mismatch was accepted'
+fi
+grep -q 'stable channel version differs in armv7/checksum.txt: expected v1.0.1, actual v1.0.0' \
+	"${TMP_ROOT}/version-mismatch.out" || fail 'architecture-specific stable version mismatch was not diagnosed'
+write_architecture_fixture armv5 || fail 'unable to restore armv5 fixture'
+
 sed "s/AI_VERSION=\"${VERSION_PATTERN}\"/AI_VERSION=\"v9.9.9\"/" "${TMP_ROOT}/installer" >"${TMP_ROOT}/installer.tmp"
 mv "${TMP_ROOT}/installer.tmp" "${TMP_ROOT}/installer"
 refresh_manifests "${TMP_ROOT}/installer"

--- a/tools/check-release-consistency.sh
+++ b/tools/check-release-consistency.sh
@@ -116,7 +116,34 @@ verify_architecture_metadata() {
 		_seen_channels="${_seen_channels}${_seen_channels:+ }${_channel}"
 		case "${_version}" in
 			version=?*) ;;
-			*) fail "invalid version in ${_channel_file} for ${_file}" ;;
+			*)
+				fail "invalid version in ${_channel_file} for ${_file}"
+				continue
+				;;
+		esac
+		_version="${_version#version=}"
+		case "${_channel}" in
+			stable)
+				if [ -z "${EXPECTED_STABLE_VERSION}" ]; then
+					EXPECTED_STABLE_VERSION="${_version}"
+				elif [ "${EXPECTED_STABLE_VERSION}" != "${_version}" ]; then
+					fail "stable channel version differs in ${_channel_file}: expected ${EXPECTED_STABLE_VERSION}, actual ${_version}"
+				fi
+				;;
+			beta)
+				if [ -z "${EXPECTED_BETA_VERSION}" ]; then
+					EXPECTED_BETA_VERSION="${_version}"
+				elif [ "${EXPECTED_BETA_VERSION}" != "${_version}" ]; then
+					fail "beta channel version differs in ${_channel_file}: expected ${EXPECTED_BETA_VERSION}, actual ${_version}"
+				fi
+				;;
+			edge)
+				if [ -z "${EXPECTED_EDGE_VERSION}" ]; then
+					EXPECTED_EDGE_VERSION="${_version}"
+				elif [ "${EXPECTED_EDGE_VERSION}" != "${_version}" ]; then
+					fail "edge channel version differs in ${_channel_file}: expected ${EXPECTED_EDGE_VERSION}, actual ${_version}"
+				fi
+				;;
 		esac
 		case "${_md5}" in
 			????????????????????????????????) ;;
@@ -189,6 +216,9 @@ if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 
 set -- installer AdGuardHome.sh S99AdGuardHome rc.func.AdGuardHome
+EXPECTED_STABLE_VERSION=""
+EXPECTED_BETA_VERSION=""
+EXPECTED_EDGE_VERSION=""
 for _directory in armv5 armv7 armv8; do
 	verify_architecture_metadata "${_directory}"
 done


### PR DESCRIPTION
### Motivation

- Ensure that the `stable`, `beta`, and `edge` channels advertise the same `version=` value across all architecture manifests so cross-architecture releases remain consistent.

### Description

- Initialize explicit POSIX state variables `EXPECTED_STABLE_VERSION`, `EXPECTED_BETA_VERSION`, and `EXPECTED_EDGE_VERSION` before processing architecture manifests in `tools/check-release-consistency.sh`.
- After validating the `version=` token, strip the `version=` prefix into a plain value and use a `case "${_channel}" in ... esac` branch to record the first-seen version per channel and fail when a later manifest advertises a different version; diagnostics include the channel, architecture manifest, expected version, and actual version.
- Add a `continue` when the `version=` field is malformed to avoid further processing of that line.
- Add a focused test in `tests/release-consistency.sh` that mutates only `armv5/checksum.txt` stable `version=` to exercise the cross-architecture mismatch path and then restores the fixture.

### Testing

- Ran `sh -n tools/check-release-consistency.sh` and `sh -n tests/release-consistency.sh` for syntax checks, both succeeded.
- Ran the full fixture suite with `sh tests/release-consistency.sh`, which completed and printed `PASS: release consistency failures are detected`.
- Ran `git diff --check` which reported no whitespace errors, and noted `shellcheck` is unavailable in the environment so static linting could not be run there.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a840bb049b483299c3c09468cbcd132)