### PR TITLE
Validate architecture-specific archive filenames in release checker and tests

### DIFF
--- a/tests/release-consistency.sh
+++ b/tests/release-consistency.sh
@@ -16,11 +16,17 @@ refresh_manifests() {
 
 write_architecture_fixture() {
 	_directory="$1"
+	case "${_directory}" in
+		armv5) _archive_arch='armv5' ;;
+		armv7) _archive_arch='armv7' ;;
+		armv8) _archive_arch='arm64' ;;
+		*) return 1 ;;
+	esac
 	mkdir -p "${TMP_ROOT}/${_directory}" || return 1
 	{
 		printf '%s\n' '# file channel version md5 sha256'
 		for _channel in stable beta edge; do
-			_file="AdGuardHome_${_channel}_linux_test.tar.gz"
+			_file="AdGuardHome_${_channel}_linux_${_archive_arch}.tar.gz"
 			printf '%s\n' "${_directory}-${_channel}" >"${TMP_ROOT}/${_directory}/${_file}" || return 1
 			refresh_manifests "${TMP_ROOT}/${_directory}/${_file}" || return 1
 			_md5="$(cat "${TMP_ROOT}/${_directory}/${_file}.md5sum")"
@@ -58,6 +64,18 @@ fi
 grep -q 'stable channel version differs in armv7/checksum.txt: expected v1.0.1, actual v1.0.0' \
 	"${TMP_ROOT}/version-mismatch.out" || fail 'architecture-specific stable version mismatch was not diagnosed'
 write_architecture_fixture armv5 || fail 'unable to restore armv5 fixture'
+
+awk 'BEGIN { OFS = "\t" } /^#/ { print; next } { if ($2 == "stable") $2 = "edge"; else if ($2 == "edge") $2 = "stable"; print }' \
+	"${TMP_ROOT}/armv7/checksum.txt" >"${TMP_ROOT}/armv7/checksum.txt.tmp"
+mv "${TMP_ROOT}/armv7/checksum.txt.tmp" "${TMP_ROOT}/armv7/checksum.txt"
+if RELEASE_ROOT="${TMP_ROOT}" sh "${TMP_ROOT}/tools/check-release-consistency.sh" >"${TMP_ROOT}/channel-filename-mismatch.out" 2>&1; then
+	fail 'swapped stable and edge channel labels were accepted'
+fi
+grep -q 'expected AdGuardHome_edge_linux_armv7.tar.gz, advertised AdGuardHome_stable_linux_armv7.tar.gz' \
+	"${TMP_ROOT}/channel-filename-mismatch.out" || fail 'stable archive with edge channel label was not diagnosed'
+grep -q 'expected AdGuardHome_stable_linux_armv7.tar.gz, advertised AdGuardHome_edge_linux_armv7.tar.gz' \
+	"${TMP_ROOT}/channel-filename-mismatch.out" || fail 'edge archive with stable channel label was not diagnosed'
+write_architecture_fixture armv7 || fail 'unable to restore armv7 fixture'
 
 sed "s/AI_VERSION=\"${VERSION_PATTERN}\"/AI_VERSION=\"v9.9.9\"/" "${TMP_ROOT}/installer" >"${TMP_ROOT}/installer.tmp"
 mv "${TMP_ROOT}/installer.tmp" "${TMP_ROOT}/installer"
@@ -109,7 +127,7 @@ fi
 write_architecture_fixture armv5 || fail 'unable to restore armv5 fixture'
 
 # Intentional glob expansion removes the advertised archive and both checksum sidecars.
-rm -f "${TMP_ROOT}/armv5/AdGuardHome_edge_linux_test.tar.gz"*
+rm -f "${TMP_ROOT}/armv5/AdGuardHome_edge_linux_armv5.tar.gz"*
 if RELEASE_ROOT="${TMP_ROOT}" sh "${TMP_ROOT}/tools/check-release-consistency.sh" >/dev/null 2>&1; then
 	fail 'missing advertised archive was accepted'
 fi

--- a/tools/check-release-consistency.sh
+++ b/tools/check-release-consistency.sh
@@ -107,6 +107,15 @@ verify_architecture_metadata() {
 				continue
 				;;
 		esac
+		case "${_directory}" in
+			armv5) _expected_file="AdGuardHome_${_channel}_linux_armv5.tar.gz" ;;
+			armv7) _expected_file="AdGuardHome_${_channel}_linux_armv7.tar.gz" ;;
+			armv8) _expected_file="AdGuardHome_${_channel}_linux_arm64.tar.gz" ;;
+		esac
+		if [ "${_file}" != "${_expected_file}" ]; then
+			fail "channel archive name mismatch in ${_channel_file}: expected ${_expected_file}, advertised ${_file}"
+			continue
+		fi
 		case " ${_seen_channels} " in
 			*" ${_channel} "*)
 				fail "duplicate ${_channel} channel in ${_channel_file}"


### PR DESCRIPTION
### Motivation

- Ensure the release consistency checker enforces the repository's exact archive naming rules per architecture and channel so mislabeled rows cannot bypass digest/version checks.
- Make test fixtures reflect real archive names and add a regression to catch swapped channel labels while keeping other metadata valid.

### Description

- In `verify_architecture_metadata()` (tools/check-release-consistency.sh) derive the exact expected archive filename from `_directory` and `_channel` and reject rows whose `_file` differs, reporting both the expected and advertised filenames; this runs after channel validation and before accepting digests or invoking `verify_artifact`.
- Implement the repository naming rules: `armv5` → `AdGuardHome_${_channel}_linux_armv5.tar.gz`, `armv7` → `AdGuardHome_${_channel}_linux_armv7.tar.gz`, and `armv8` → `AdGuardHome_${_channel}_linux_arm64.tar.gz`.
- Update `write_architecture_fixture()` (tests/release-consistency.sh) to generate archive names using the architecture-specific suffixes (`armv5`, `armv7`, `arm64`) instead of the previous `linux_test` placeholder.
- Add a regression case in `tests/release-consistency.sh` that swaps `stable` and `edge` channel fields for the `armv7` fixture, asserts the checker rejects the mislabeled rows with diagnostics that include expected vs advertised filenames, and then regenerates the affected fixture.
- Adjust the missing-archive test to reference the new architecture-specific filename for `armv5`.

### Testing

- Ran a syntax check: `sh -n tools/check-release-consistency.sh tests/release-consistency.sh` and it succeeded with no syntax errors.
- Executed the test suite: `sh tests/release-consistency.sh` and it completed successfully, printing `PASS: release consistency failures are detected`.
- Ran whitespace/checks: `git diff --check` returned clean (no trailing-whitespace errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a84b00e553c8329ab2dd5971a8900fe)