### PR TITLE
tests: handle shared-prefix stale-version boundary in release-consistency test

### DIFF
--- a/tests/release-consistency.sh
+++ b/tests/release-consistency.sh
@@ -107,7 +107,8 @@ refresh_manifests "${TMP_ROOT}/installer"
 if RELEASE_ROOT="${TMP_ROOT}" sh "${TMP_ROOT}/tools/check-release-consistency.sh" >/dev/null 2>&1; then
 	fail 'malformed dotted release version was accepted'
 fi
-BOUNDARY_VERSION="${CURRENT_VERSION}0"
+STALE_VERSION="${CURRENT_VERSION%.*}.1"
+BOUNDARY_VERSION="${STALE_VERSION}0"
 sed "s/${VERSION_PATTERN}/${BOUNDARY_VERSION}/g" installer >"${TMP_ROOT}/installer"
 refresh_manifests "${TMP_ROOT}/installer"
 RELEASE_ROOT="${TMP_ROOT}" sh "${TMP_ROOT}/tools/check-release-consistency.sh" >/dev/null ||
@@ -115,7 +116,6 @@ RELEASE_ROOT="${TMP_ROOT}" sh "${TMP_ROOT}/tools/check-release-consistency.sh" >
 cp installer "${TMP_ROOT}/installer"
 refresh_manifests "${TMP_ROOT}/installer"
 
-STALE_VERSION="${CURRENT_VERSION%.*}.1"
 if [ "${STALE_VERSION}" != "${CURRENT_VERSION}" ]; then
 	printf '%s\n' "# stale release ${STALE_VERSION}" >>"${TMP_ROOT}/installer"
 	refresh_manifests "${TMP_ROOT}/installer"


### PR DESCRIPTION
### Motivation

- Ensure the release-consistency test covers the numeric-prefix boundary case where a stale identifier like `v2.6.1` is a numeric prefix of a valid two-digit patch like `v2.6.10`.
- Reuse the same stale identifier in both the boundary and exact-stale tests to avoid duplicated derivation logic and make the intent explicit.

### Description

- Moved the `STALE_VERSION` assignment earlier in `tests/release-consistency.sh` so it is available to both cases and set `BOUNDARY_VERSION` with `BOUNDARY_VERSION="${STALE_VERSION}0"` instead of appending `0` to `CURRENT_VERSION`.
- Replace the installer fixture occurrences using the computed `BOUNDARY_VERSION` and refresh the fixture checksums with the existing `refresh_manifests` helper so MD5 and SHA-256 sidecars remain consistent.
- Preserve the separate test that appends the exact stale identifier `STALE_VERSION` to the installer and asserts the consistency checker rejects that exact stale identifier.
- Changes are confined to `tests/release-consistency.sh` and follow the repository's existing manifest-refresh and assertion patterns.

### Testing

- Ran `git diff --check` with no issues reported.
- Verified POSIX syntax with `sh -n tests/release-consistency.sh` which completed successfully.
- Executed the test script with `sh tests/release-consistency.sh` which completed and printed the expected `PASS` message indicating the checks detected expected inconsistencies.
- `shellcheck -s sh tests/release-consistency.sh` was not run because `shellcheck` is unavailable in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a84b06d3d348329bfe5fce8b1082b1c)