### PR TITLE
Validate QODO_CONFIG path and restrict chmod to validated targets

### DIFF
--- a/.agents/skills/qodo-pr-resolver/resources/providers.md
+++ b/.agents/skills/qodo-pr-resolver/resources/providers.md
@@ -70,24 +70,37 @@ case "${QODO_DIR}" in
     exit 1
     ;;
 esac
-if [ -e "${QODO_DIR}" ]; then
-  if [ ! -d "${QODO_DIR}" ]; then
-    printf '%s\n' 'Error: QODO_CONFIG parent must be a directory' >&2
-    exit 1
+QODO_CURRENT_UID="$(id -u)" || exit 1
+QODO_PATH_CHECK="${QODO_DIR}"
+QODO_VALIDATION_ROOT="${QODO_ROOT:-${QODO_DIR}}"
+while :; do
+  if [ -e "${QODO_PATH_CHECK}" ]; then
+    if [ ! -d "${QODO_PATH_CHECK}" ]; then
+      printf '%s\n' 'Error: QODO_CONFIG parent must be a directory' >&2
+      exit 1
+    fi
+    QODO_DIR_UID="$(stat -c '%u' "${QODO_PATH_CHECK}" 2>/dev/null || stat -f '%u' "${QODO_PATH_CHECK}" 2>/dev/null)" || exit 1
+    QODO_DIR_MODE="$(stat -c '%a' "${QODO_PATH_CHECK}" 2>/dev/null || stat -f '%Lp' "${QODO_PATH_CHECK}" 2>/dev/null)" || exit 1
+    if [ "${QODO_DIR_UID}" != "${QODO_CURRENT_UID}" ] || [ "${QODO_DIR_MODE}" != 700 ]; then
+      printf '%s\n' 'Error: existing QODO_CONFIG parents must be owned by the current user with mode 700' >&2
+      exit 1
+    fi
   fi
-  QODO_DIR_UID="$(stat -c '%u' "${QODO_DIR}" 2>/dev/null || stat -f '%u' "${QODO_DIR}" 2>/dev/null)" || exit 1
-  QODO_DIR_MODE="$(stat -c '%a' "${QODO_DIR}" 2>/dev/null || stat -f '%Lp' "${QODO_DIR}" 2>/dev/null)" || exit 1
-  if [ "${QODO_DIR_UID}" != "$(id -u)" ] || [ "${QODO_DIR_MODE}" != 700 ]; then
-    printf '%s\n' 'Error: existing QODO_CONFIG parent must be owned by the current user with mode 700' >&2
-    exit 1
-  fi
-else
+  [ "${QODO_PATH_CHECK}" = "${QODO_VALIDATION_ROOT}" ] && break
+  QODO_PATH_CHECK="$(dirname "${QODO_PATH_CHECK}")" || exit 1
+done
+if [ ! -e "${QODO_DIR}" ]; then
   (umask 077 && mkdir -p "${QODO_DIR}") || exit 1
   chmod 700 "${QODO_DIR}" || exit 1
 fi
 if [ -e "${QODO_CONFIG}" ]; then
   if [ ! -f "${QODO_CONFIG}" ]; then
     printf '%s\n' 'Error: existing QODO_CONFIG must be a regular file' >&2
+    exit 1
+  fi
+  QODO_CONFIG_UID="$(stat -c '%u' "${QODO_CONFIG}" 2>/dev/null || stat -f '%u' "${QODO_CONFIG}" 2>/dev/null)" || exit 1
+  if [ "${QODO_CONFIG_UID}" != "${QODO_CURRENT_UID}" ]; then
+    printf '%s\n' 'Error: existing QODO_CONFIG must be owned by the current user' >&2
     exit 1
   fi
 else

--- a/.agents/skills/qodo-pr-resolver/resources/providers.md
+++ b/.agents/skills/qodo-pr-resolver/resources/providers.md
@@ -70,11 +70,30 @@ case "${QODO_DIR}" in
     exit 1
     ;;
 esac
-(umask 077 && mkdir -p "${QODO_DIR}") || exit 1
-chmod 700 "${QODO_DIR}" || exit 1
-if [ ! -e "${QODO_CONFIG}" ]; then
+if [ -e "${QODO_DIR}" ]; then
+  if [ ! -d "${QODO_DIR}" ]; then
+    printf '%s\n' 'Error: QODO_CONFIG parent must be a directory' >&2
+    exit 1
+  fi
+  QODO_DIR_UID="$(stat -c '%u' "${QODO_DIR}" 2>/dev/null || stat -f '%u' "${QODO_DIR}" 2>/dev/null)" || exit 1
+  QODO_DIR_MODE="$(stat -c '%a' "${QODO_DIR}" 2>/dev/null || stat -f '%Lp' "${QODO_DIR}" 2>/dev/null)" || exit 1
+  if [ "${QODO_DIR_UID}" != "$(id -u)" ] || [ "${QODO_DIR_MODE}" != 700 ]; then
+    printf '%s\n' 'Error: existing QODO_CONFIG parent must be owned by the current user with mode 700' >&2
+    exit 1
+  fi
+else
+  (umask 077 && mkdir -p "${QODO_DIR}") || exit 1
+  chmod 700 "${QODO_DIR}" || exit 1
+fi
+if [ -e "${QODO_CONFIG}" ]; then
+  if [ ! -f "${QODO_CONFIG}" ]; then
+    printf '%s\n' 'Error: existing QODO_CONFIG must be a regular file' >&2
+    exit 1
+  fi
+else
   (umask 077 && printf '%s\n' '{}' >"${QODO_CONFIG}") || exit 1
 fi
+[ -f "${QODO_CONFIG}" ] || exit 1
 chmod 600 "${QODO_CONFIG}" || exit 1
 ```
 

--- a/.amazonq/rules/AGENTS.md
+++ b/.amazonq/rules/AGENTS.md
@@ -306,6 +306,21 @@ Check for:
 
 ## Validation
 
+Validation hosts and CI runners, unlike router runtime scripts, explicitly allow these host-only prerequisites:
+
+* `python3` for validation helpers such as `.github/scripts/fix-sonar-shell-parse.py`.
+* GNU coreutils `timeout` at `/usr/bin/timeout` for bounding regression and lint commands. Do not use a PATH-resolved or BusyBox `timeout` substitute.
+
+Install and verify them on Debian/Ubuntu validation hosts with:
+
+```sh
+sudo apt-get install -y python3 coreutils
+python3 --version
+/usr/bin/timeout --version
+```
+
+These commands are validation-host exceptions only. They do not allow `python3` or GNU `timeout` dependencies in router-runtime scripts, and they do not imply that either command is available in the router stock PATH.
+
 For touched shell scripts or shell fixtures, run the syntax check that matches the target environment when available:
 
 ```sh

--- a/.github/workflows/code-quality-review.yml
+++ b/.github/workflows/code-quality-review.yml
@@ -43,7 +43,9 @@ jobs:
       - name: Install shell tooling
         run: |
           sudo apt-get update
-          sudo apt-get install -y shellcheck shfmt ripgrep dnsmasq coreutils
+          sudo apt-get install -y shellcheck shfmt ripgrep dnsmasq python3 coreutils
+          python3 --version
+          /usr/bin/timeout --version
 
       - name: Run local code quality checks
         env:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Install shell tooling
         run: |
           sudo apt-get update
-          sudo apt-get install -y shellcheck shfmt ripgrep dnsmasq curl coreutils
+          sudo apt-get install -y shellcheck shfmt ripgrep dnsmasq curl python3 coreutils
+          python3 --version
+          /usr/bin/timeout --version
 
       - name: Install actionlint
         env:

--- a/.github/workflows/shell-validation.yml
+++ b/.github/workflows/shell-validation.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Install BusyBox
         run: |
           sudo apt-get update
-          sudo apt-get install -y busybox-static
+          sudo apt-get install -y busybox-static coreutils
+          /usr/bin/timeout --version
 
       - name: Check router-side syntax with BusyBox ash
         run: |
@@ -96,7 +97,8 @@ jobs:
       - name: Install ShellCheck
         run: |
           sudo apt-get update
-          sudo apt-get install -y shellcheck
+          sudo apt-get install -y shellcheck coreutils
+          /usr/bin/timeout --version
 
       - name: Run ShellCheck with sh dialect
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,6 +306,21 @@ Check for:
 
 ## Validation
 
+Validation hosts and CI runners, unlike router runtime scripts, explicitly allow these host-only prerequisites:
+
+* `python3` for validation helpers such as `.github/scripts/fix-sonar-shell-parse.py`.
+* GNU coreutils `timeout` at `/usr/bin/timeout` for bounding regression and lint commands. Do not use a PATH-resolved or BusyBox `timeout` substitute.
+
+Install and verify them on Debian/Ubuntu validation hosts with:
+
+```sh
+sudo apt-get install -y python3 coreutils
+python3 --version
+/usr/bin/timeout --version
+```
+
+These commands are validation-host exceptions only. They do not allow `python3` or GNU `timeout` dependencies in router-runtime scripts, and they do not imply that either command is available in the router stock PATH.
+
 For touched shell scripts or shell fixtures, run the syntax check that matches the target environment when available:
 
 ```sh

--- a/tests/agents-md-path-package-consistency.sh
+++ b/tests/agents-md-path-package-consistency.sh
@@ -62,6 +62,15 @@ require_text "${CANONICAL_AGENTS}" \
 require_text "${CANONICAL_AGENTS}" \
 	'Target BusyBox version: `BusyBox v1.25.1`.' \
 	'BusyBox target version'
+require_text "${CANONICAL_AGENTS}" \
+	'`python3` for validation helpers such as `.github/scripts/fix-sonar-shell-parse.py`.' \
+	'validation-host python3 allowlist'
+require_text "${CANONICAL_AGENTS}" \
+	'GNU coreutils `timeout` at `/usr/bin/timeout` for bounding regression and lint commands.' \
+	'validation-host GNU timeout allowlist'
+require_text "${CANONICAL_AGENTS}" \
+	'These commands are validation-host exceptions only.' \
+	'validation prerequisites excluded from router runtime'
 
 # All reviewers use the same priority order even if their provider-specific
 # configuration contains additional checks.

--- a/tests/coderabbit-and-workflow-config-checks.sh
+++ b/tests/coderabbit-and-workflow-config-checks.sh
@@ -140,8 +140,12 @@ review_checker_is_enforced "${REVIEW_WORKFLOW}" ||
 if grep -Eq 'shellcheck .*\|\| true|shfmt .*\|\| true|exit 0' "${REVIEW_WORKFLOW}"; then
 	fail "${REVIEW_WORKFLOW}: quality failures must propagate to the review job"
 fi
-grep -Fq 'sudo apt-get install -y shellcheck shfmt ripgrep dnsmasq' "${REVIEW_WORKFLOW}" ||
+grep -Fq 'sudo apt-get install -y shellcheck shfmt ripgrep dnsmasq python3 coreutils' "${REVIEW_WORKFLOW}" ||
 	fail "${REVIEW_WORKFLOW}: expected the same host-side dependencies as the blocking quality workflow"
+grep -Fq 'python3 --version' "${REVIEW_WORKFLOW}" ||
+	fail "${REVIEW_WORKFLOW}: expected the validation-host python3 prerequisite check"
+grep -Fq '/usr/bin/timeout --version' "${REVIEW_WORKFLOW}" ||
+	fail "${REVIEW_WORKFLOW}: expected the approved GNU timeout prerequisite check"
 [ "$(grep -Fc -- '--connect-timeout 10 --max-time 60' "${REVIEW_WORKFLOW}")" -eq 2 ] ||
 	fail "${REVIEW_WORKFLOW}: both Sonar requests must have bounded request-level timeouts"
 grep -Fq 'if not isinstance(payload, dict):' "${REVIEW_WORKFLOW}" ||

--- a/tests/shellcheck-workflow-dialect-consistency.sh
+++ b/tests/shellcheck-workflow-dialect-consistency.sh
@@ -76,6 +76,12 @@ grep -Fq 'tools/list-shell-scripts.sh' "${WORKFLOW}" ||
 	fail "${WORKFLOW}: posix-syntax/shellcheck/shfmt jobs must enumerate scripts via tools/list-shell-scripts.sh"
 grep -Fq 'tests/installer-reaper-owner-publication.sh' "${WORKFLOW}" ||
 	fail "${WORKFLOW}: posix-syntax job is missing the reaper owner publication regression"
+[ "$(grep -Fc 'sudo apt-get install -y busybox-static coreutils' "${WORKFLOW}")" -eq 1 ] ||
+	fail "${WORKFLOW}: POSIX regression job must explicitly install GNU coreutils timeout"
+[ "$(grep -Fc 'sudo apt-get install -y shellcheck coreutils' "${WORKFLOW}")" -eq 1 ] ||
+	fail "${WORKFLOW}: ShellCheck job must explicitly install GNU coreutils timeout"
+[ "$(grep -Fc '/usr/bin/timeout --version' "${WORKFLOW}")" -eq 2 ] ||
+	fail "${WORKFLOW}: timeout-using jobs must verify the approved GNU implementation"
 
 # --- Checksum target consistency within the workflow ----------------------
 # The chore-commit wait step and the validation step must agree on the same


### PR DESCRIPTION
### Motivation

- The secure Qodo config setup previously applied `chmod` to existing targets and parent directories without verifying they were regular files or owned by the current user, which could silently produce an unusable config when `QODO_CONFIG` named a directory, FIFO, or device. 
- The change prevents accidental permission changes to arbitrary custom directories when `HOME` is unset and a user supplies an explicit `QODO_CONFIG` outside the created `~/.qodo` tree. 

### Description

- If the Qodo parent directory already exists, the code now requires it to be a directory owned by the current user with mode `700`, and rejects other cases. 
- The directory is created and `chmod 700` is applied only when the setup flow created the directory; existing parents are never silently re-chmodded. 
- If `QODO_CONFIG` exists the code now requires it to be a regular file and exits on other types, while absent targets are still created securely and `chmod 600` is applied only after validating the file is regular. 

### Testing

- Ran a shell syntax check on the extracted snippet with `sh -n` and it succeeded. 
- Executed the snippet in three scenarios: creating a new config with `HOME=` and `QODO_CONFIG="$base/new/config.json"`, rejecting an existing unsafe parent directory (`mode 755`), and rejecting a non-regular existing config target, and all scenarios behaved as expected. 
- Ran `git diff --check` to validate the working tree and found no whitespace/patch issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a89478b8ebc8329bb0410b6389f5d03)