### PR TITLE
ci: add workflow to refresh tzdata packages and generate .md5sum/.sha256sum sidecars

### DIFF
--- a/.github/workflows/update-tzdata.yml
+++ b/.github/workflows/update-tzdata.yml
@@ -1,0 +1,128 @@
+name: Update tzdata packages
+
+on:
+  schedule:
+    - cron: '23 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: update-tzdata-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  update-tzdata:
+    name: Update ARM tzdata packages
+    if: github.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Download current packages
+        shell: bash
+        env:
+          MIRROR_URL: https://mirror.archlinuxarm.org
+        run: |
+          set -euo pipefail
+
+          stage_dir="$(mktemp -d)"
+          trap 'rm -rf "${stage_dir}"' EXIT
+
+          download_package() {
+            local architecture output_arch database description filename package_url
+            local upstream_file package_info package_version package_arch output_file
+            architecture="$1"
+            output_arch="$2"
+            database="${stage_dir}/core-${architecture}.db"
+
+            curl --fail --location --silent --show-error \
+              --connect-timeout 15 --max-time 120 \
+              "${MIRROR_URL}/${architecture}/core/core.db" \
+              --output "${database}"
+            description="$(tar -xOf "${database}" 'tzdata-*/desc')"
+            filename="$(printf '%s\n' "${description}" | awk '$0 == "%FILENAME%" { getline; print; exit }')"
+            case "${filename}" in
+              tzdata-*.pkg.tar.bz2|tzdata-*.pkg.tar.xz|tzdata-*.pkg.tar.zst) ;;
+              *)
+                printf 'Unexpected tzdata filename for %s: %s\n' "${architecture}" "${filename}" >&2
+                return 1
+                ;;
+            esac
+            [ "${filename}" = "$(basename "${filename}")" ] || return 1
+
+            package_url="${MIRROR_URL}/${architecture}/core/${filename}"
+            upstream_file="${stage_dir}/${filename}"
+            curl --fail --location --silent --show-error \
+              --connect-timeout 15 --max-time 300 \
+              "${package_url}" --output "${upstream_file}"
+            package_info="$(tar -xOf "${upstream_file}" ./.PKGINFO)"
+            package_version="$(printf '%s\n' "${package_info}" | awk -F ' = ' '$1 == "pkgver" { print $2; exit }')"
+            package_arch="$(printf '%s\n' "${package_info}" | awk -F ' = ' '$1 == "arch" { print $2; exit }')"
+            case "${package_version}" in
+              ''|*[!A-Za-z0-9._+-]*) return 1 ;;
+            esac
+            case "${package_arch}:${architecture}" in
+              aarch64:aarch64|armv7h:armv7h|any:*) ;;
+              *)
+                printf 'Package architecture mismatch: %s for %s\n' "${package_arch}" "${architecture}" >&2
+                return 1
+                ;;
+            esac
+
+            output_file="${stage_dir}/tzdata-${package_version}-${output_arch}.pkg.tar.bz2"
+            case "${upstream_file}" in
+              *.bz2) cp "${upstream_file}" "${output_file}" ;;
+              *.xz) xz --decompress --stdout "${upstream_file}" | bzip2 -9 >"${output_file}" ;;
+              *.zst) zstd --decompress --stdout "${upstream_file}" | bzip2 -9 >"${output_file}" ;;
+            esac
+            tar -tjf "${output_file}" >/dev/null
+            printf '%s\n' "${package_version}" >"${stage_dir}/version-${output_arch}"
+          }
+
+          download_package aarch64 aarch64
+          download_package armv7h arm
+
+          aarch64_version="$(cat "${stage_dir}/version-aarch64")"
+          arm_version="$(cat "${stage_dir}/version-arm")"
+          if [ "${aarch64_version}" != "${arm_version}" ]; then
+            printf 'tzdata versions differ: aarch64=%s arm=%s\n' "${aarch64_version}" "${arm_version}" >&2
+            exit 1
+          fi
+
+          rm -f tzdata-*-aarch64.pkg.tar.bz2 tzdata-*-aarch64.pkg.tar.bz2.md5sum tzdata-*-aarch64.pkg.tar.bz2.sha256sum
+          rm -f tzdata-*-arm.pkg.tar.bz2 tzdata-*-arm.pkg.tar.bz2.md5sum tzdata-*-arm.pkg.tar.bz2.sha256sum
+          mv "${stage_dir}/tzdata-${aarch64_version}-aarch64.pkg.tar.bz2" .
+          mv "${stage_dir}/tzdata-${arm_version}-arm.pkg.tar.bz2" .
+
+          sed -i "s/TZ_DATA=\"tzdata-[^\"]*-\${TZ_ARCH}\.pkg\.tar\.bz2\"/TZ_DATA=\"tzdata-${aarch64_version}-\${TZ_ARCH}.pkg.tar.bz2\"/" installer
+          sh tools/update-checksums.sh \
+            "tzdata-${aarch64_version}-aarch64.pkg.tar.bz2" \
+            "tzdata-${arm_version}-arm.pkg.tar.bz2" \
+            installer
+
+      - name: Commit package updates
+        shell: bash
+        env:
+          PUSH_TARGET: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$(git status --porcelain -- installer installer.md5sum installer.sha256sum 'tzdata-*')" ]; then
+            echo 'tzdata packages are already current.'
+            exit 0
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -- installer installer.md5sum installer.sha256sum tzdata-*
+          git commit -m 'chore: update tzdata packages'
+          git push origin "HEAD:${PUSH_TARGET}"

--- a/.github/workflows/update-tzdata.yml
+++ b/.github/workflows/update-tzdata.yml
@@ -4,12 +4,17 @@ on:
   schedule:
     - cron: '23 4 * * 1'
   workflow_dispatch:
+    inputs:
+      target_branch:
+        description: Branch to update; defaults to the branch selected when starting the workflow
+        required: false
+        default: ''
 
 permissions:
   contents: read
 
 concurrency:
-  group: update-tzdata-${{ github.ref }}
+  group: update-tzdata-${{ inputs.target_branch || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -21,9 +26,38 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout branch
+      - name: Resolve target branch
+        id: branch
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TARGET_BRANCH: ${{ inputs.target_branch }}
+        run: |
+          set -euo pipefail
+
+          if [ "${EVENT_NAME}" = 'workflow_dispatch' ] && [ -n "${INPUT_TARGET_BRANCH}" ]; then
+            target_branch="${INPUT_TARGET_BRANCH}"
+          else
+            target_branch="${GITHUB_REF_NAME}"
+          fi
+
+          case "${target_branch}" in
+            ''|*..*|/*|*[^A-Za-z0-9._/-]*|*'~'*|*'^'*|*':'*|*'?'*|*'['*|*'\'*)
+              printf 'Invalid target branch: %s\n' "${target_branch}" >&2
+              exit 1
+              ;;
+          esac
+          if ! git check-ref-format --branch "${target_branch}" >/dev/null 2>&1; then
+            printf 'Invalid target branch: %s\n' "${target_branch}" >&2
+            exit 1
+          fi
+
+          printf 'target=%s\n' "${target_branch}" >>"${GITHUB_OUTPUT}"
+
+      - name: Checkout target branch
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
+          ref: ${{ steps.branch.outputs.target }}
           fetch-depth: 0
           persist-credentials: true
 
@@ -203,7 +237,7 @@ jobs:
       - name: Commit package updates
         shell: bash
         env:
-          PUSH_TARGET: ${{ github.ref_name }}
+          PUSH_TARGET: ${{ steps.branch.outputs.target }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/update-tzdata.yml
+++ b/.github/workflows/update-tzdata.yml
@@ -31,24 +31,59 @@ jobs:
         shell: bash
         env:
           MIRROR_URL: https://mirror.archlinuxarm.org
+          SIGNING_KEY_FINGERPRINT: 68B3537F39A313B3E574D06777193F152BDBE6A6
         run: |
           set -euo pipefail
 
           stage_dir="$(mktemp -d)"
           trap 'rm -rf "${stage_dir}"' EXIT
+          export GNUPGHOME="${stage_dir}/gnupg"
+          mkdir -m 700 "${GNUPGHOME}"
+
+          gpg --batch --keyserver hkps://keyserver.ubuntu.com \
+            --keyserver-options timeout=30 \
+            --recv-keys "${SIGNING_KEY_FINGERPRINT}"
+          imported_fingerprint="$(gpg --batch --with-colons --fingerprint "${SIGNING_KEY_FINGERPRINT}" |
+            awk -F: '$1 == "fpr" { print $10; exit }')"
+          if [ "${imported_fingerprint}" != "${SIGNING_KEY_FINGERPRINT}" ]; then
+            printf 'Unexpected Arch Linux ARM signing-key fingerprint: %s\n' "${imported_fingerprint}" >&2
+            exit 1
+          fi
+
+          verify_signature() {
+            local signed_file signature_file valid_signature
+            signed_file="$1"
+            signature_file="$2"
+            valid_signature="$(gpg --batch --status-fd 1 --verify "${signature_file}" "${signed_file}" 2>/dev/null |
+              awk -v fingerprint="${SIGNING_KEY_FINGERPRINT}" \
+                '$1 == "[GNUPG:]" && $2 == "VALIDSIG" && ($3 == fingerprint || $NF == fingerprint) { print $3; exit }')"
+            if [ -z "${valid_signature}" ]; then
+              printf 'Signature verification failed for %s\n' "${signed_file}" >&2
+              return 1
+            fi
+          }
 
           download_package() {
-            local architecture output_arch database description filename package_url
-            local upstream_file package_info package_version package_arch output_file
+            local architecture output_arch database database_signature description filename package_url
+            local upstream_file upstream_signature package_info package_version package_arch output_file
             architecture="$1"
             output_arch="$2"
             database="${stage_dir}/core-${architecture}.db"
 
             curl --fail --location --silent --show-error \
+              --proto '=https' --proto-redir '=https' \
               --connect-timeout 15 --max-time 120 \
               "${MIRROR_URL}/${architecture}/core/core.db" \
               --output "${database}"
-            description="$(tar -xOf "${database}" 'tzdata-*/desc')"
+            database_signature="${database}.sig"
+            curl --fail --location --silent --show-error \
+              --proto '=https' --proto-redir '=https' \
+              --connect-timeout 15 --max-time 120 \
+              "${MIRROR_URL}/${architecture}/core/core.db.sig" \
+              --output "${database_signature}"
+            verify_signature "${database}" "${database_signature}"
+
+            description="$(tar --wildcards -xOf "${database}" 'tzdata-*/desc')"
             filename="$(printf '%s\n' "${description}" | awk '$0 == "%FILENAME%" { getline; print; exit }')"
             case "${filename}" in
               tzdata-*.pkg.tar.bz2|tzdata-*.pkg.tar.xz|tzdata-*.pkg.tar.zst) ;;
@@ -57,16 +92,34 @@ jobs:
                 return 1
                 ;;
             esac
-            [ "${filename}" = "$(basename "${filename}")" ] || return 1
+            if [ "${filename}" != "$(basename "${filename}")" ]; then
+              printf 'Filename contains path separators: %s\n' "${filename}" >&2
+              return 1
+            fi
 
             package_url="${MIRROR_URL}/${architecture}/core/${filename}"
-            upstream_file="${stage_dir}/${filename}"
+            upstream_file="${stage_dir}/upstream-${architecture}.${filename##*.}"
+            upstream_signature="${upstream_file}.sig"
             curl --fail --location --silent --show-error \
+              --proto '=https' --proto-redir '=https' \
               --connect-timeout 15 --max-time 300 \
               "${package_url}" --output "${upstream_file}"
-            package_info="$(tar -xOf "${upstream_file}" ./.PKGINFO)"
+            curl --fail --location --silent --show-error \
+              --proto '=https' --proto-redir '=https' \
+              --connect-timeout 15 --max-time 120 \
+              "${package_url}.sig" --output "${upstream_signature}"
+            verify_signature "${upstream_file}" "${upstream_signature}"
+
+            if ! package_info="$(tar -xOf "${upstream_file}" ./.PKGINFO 2>/dev/null)"; then
+              printf 'Failed to extract .PKGINFO from %s\n' "${upstream_file}" >&2
+              return 1
+            fi
             package_version="$(printf '%s\n' "${package_info}" | awk -F ' = ' '$1 == "pkgver" { print $2; exit }')"
             package_arch="$(printf '%s\n' "${package_info}" | awk -F ' = ' '$1 == "arch" { print $2; exit }')"
+            if [ -z "${package_version}" ] || [ -z "${package_arch}" ]; then
+              printf 'Failed to extract version or architecture from .PKGINFO\n' >&2
+              return 1
+            fi
             case "${package_version}" in
               ''|*[!A-Za-z0-9._+-]*) return 1 ;;
             esac
@@ -85,6 +138,27 @@ jobs:
               *.zst) zstd --decompress --stdout "${upstream_file}" | bzip2 -9 >"${output_file}" ;;
             esac
             tar -tjf "${output_file}" >/dev/null
+            if ! tar -tjf "${output_file}" |
+              awk '/^\.\/usr\/share\/zoneinfo\/posix\/./ && !/\/$/ { found = 1 } END { exit !found }'; then
+              printf 'Package has no usable ./usr/share/zoneinfo/posix payload: %s\n' "${filename}" >&2
+              return 1
+            fi
+            python3 - "${output_file}" <<'PY'
+          import posixpath
+          import sys
+          import tarfile
+
+          archive = sys.argv[1]
+          with tarfile.open(archive, "r:bz2") as package:
+              for member in package.getmembers():
+                  normalized_name = posixpath.normpath(member.name)
+                  if member.name.startswith("/") or normalized_name == ".." or normalized_name.startswith("../"):
+                      raise SystemExit(f"Unsafe archive member path: {member.name}")
+                  if member.issym() or member.islnk():
+                      link_path = posixpath.normpath(posixpath.join(posixpath.dirname(normalized_name), member.linkname))
+                      if member.linkname.startswith("/") or link_path == ".." or link_path.startswith("../"):
+                          raise SystemExit(f"Unsafe archive link: {member.name} -> {member.linkname}")
+          PY
             printf '%s\n' "${package_version}" >"${stage_dir}/version-${output_arch}"
           }
 
@@ -98,12 +172,29 @@ jobs:
             exit 1
           fi
 
+          # These globs intentionally remove every superseded package and sidecar.
           rm -f tzdata-*-aarch64.pkg.tar.bz2 tzdata-*-aarch64.pkg.tar.bz2.md5sum tzdata-*-aarch64.pkg.tar.bz2.sha256sum
           rm -f tzdata-*-arm.pkg.tar.bz2 tzdata-*-arm.pkg.tar.bz2.md5sum tzdata-*-arm.pkg.tar.bz2.sha256sum
+          if [ ! -f "${stage_dir}/tzdata-${aarch64_version}-aarch64.pkg.tar.bz2" ]; then
+            printf 'aarch64 package file not found\n' >&2
+            exit 1
+          fi
+          if [ ! -f "${stage_dir}/tzdata-${arm_version}-arm.pkg.tar.bz2" ]; then
+            printf 'arm package file not found\n' >&2
+            exit 1
+          fi
           mv "${stage_dir}/tzdata-${aarch64_version}-aarch64.pkg.tar.bz2" .
           mv "${stage_dir}/tzdata-${arm_version}-arm.pkg.tar.bz2" .
 
+          if ! grep -Eq '^[[:space:]]*TZ_DATA="tzdata-[^"]*-\$\{TZ_ARCH\}\.pkg\.tar\.bz2"$' installer; then
+            printf 'Expected TZ_DATA assignment not found in installer\n' >&2
+            exit 1
+          fi
           sed -i "s/TZ_DATA=\"tzdata-[^\"]*-\${TZ_ARCH}\.pkg\.tar\.bz2\"/TZ_DATA=\"tzdata-${aarch64_version}-\${TZ_ARCH}.pkg.tar.bz2\"/" installer
+          if ! grep -Fq "TZ_DATA=\"tzdata-${aarch64_version}-\${TZ_ARCH}.pkg.tar.bz2\"" installer; then
+            printf 'Failed to update TZ_DATA in installer\n' >&2
+            exit 1
+          fi
           sh tools/update-checksums.sh \
             "tzdata-${aarch64_version}-aarch64.pkg.tar.bz2" \
             "tzdata-${arm_version}-arm.pkg.tar.bz2" \
@@ -123,6 +214,8 @@ jobs:
 
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add -- installer installer.md5sum installer.sha256sum tzdata-*
+          git add -- installer installer.md5sum installer.sha256sum
+          # The quoted Git pathspec intentionally stages new files and tracked removals.
+          git add -A -- 'tzdata-*'
           git commit -m 'chore: update tzdata packages'
           git push origin "HEAD:${PUSH_TARGET}"


### PR DESCRIPTION
### Motivation

- Keep the repository-hosted `tzdata` packages for `aarch64` and `arm` current and fully checksumed so router installs use validated timezone archives.
- Automate safe retrieval, validation, and atomic replacement of the two architecture-specific `pkg.tar.bz2` artifacts and the installer reference to reduce manual maintenance and drift.

### Description

- Add `.github/workflows/update-tzdata.yml`, a scheduled and manual GitHub Actions job that fetches Arch Linux ARM `core.db`, extracts the `tzdata` package filename and metadata, and downloads the upstream package for `aarch64` and `armv7h`.
- Validate upstream metadata from `./.PKGINFO`, enforce filename and architecture checks, perform an integrity `tar` test, and convert upstream `xz`/`zst` packages to `.pkg.tar.bz2` when needed before staging the repository artifacts.
- Update the installer's `TZ_DATA` reference with the new version and call `sh tools/update-checksums.sh` to generate normalized `.md5sum` and `.sha256sum` sidecars for each package and the `installer` script.
- Run with least-privilege `permissions: contents: read` at the workflow top level and `contents: write` only inside the job, use a concurrency group, and commit/push changes only when checksumed files or the installer reference actually change.

### Testing

- `git diff --check` was run and reported no whitespace/patch issues, and it passed.
- The workflow YAML was parsed with Ruby (`YAML.load_file`) and validated as syntactically correct, and that check passed.
- Repository CI/workflow gating checks were executed via `sh tests/coderabbit-and-workflow-config-checks.sh` and the test passed (output: `PASS`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8cb172b2448329b4efe19a922c9e9b)