### PR TITLE
Update tzdata workflow triggers and mirror; make DNS test blocking probe robust

### DIFF
--- a/.github/workflows/update-tzdata.yml
+++ b/.github/workflows/update-tzdata.yml
@@ -1,6 +1,15 @@
-name: Update tzdata packages
+name: Update Tz-data packages
 
 on:
+  push:
+    branches:
+      - master
+      - main
+      - dev
+      - 'dev/**'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+    paths:
+      - .github/workflows/update-tzdata.yml
   schedule:
     - cron: '23 4 * * 1'
   workflow_dispatch:
@@ -64,7 +73,7 @@ jobs:
       - name: Download current packages
         shell: bash
         env:
-          MIRROR_URL: https://mirror.archlinuxarm.org
+          MIRROR_URL: https://de.mirror.archlinuxarm.org
           SIGNING_KEY_FINGERPRINT: 68B3537F39A313B3E574D06777193F152BDBE6A6
         run: |
           set -euo pipefail

--- a/tests/installer-dns-environment-failure.sh
+++ b/tests/installer-dns-environment-failure.sh
@@ -289,7 +289,13 @@ nslookup() {
 	if [ "${TRACK_LOOKUP:-0}" = 1 ]; then
 		trap 'printf "%s\n" reaped >"${TEST_ROOT}/lookup-reaped"; exit 1' TERM
 	fi
-	[ "${BLOCKING_QUERY:-0}" = 0 ] || /bin/sleep 5
+	# Keep the probe blocked until the deadline logic terminates it. Using an
+	# external sleep here can leave the shell waiting on, or orphan, the sleep
+	# process after TERM on loaded CI runners and makes the probe-count assertion
+	# timing-dependent.
+	if [ "${BLOCKING_QUERY:-0}" != 0 ]; then
+		while :; do :; done
+	fi
 	[ "${DNS_READY_AFTER_SERVICE:-0}" -eq 0 ] || [ "${SERVICE_COUNT}" -lt "${DNS_READY_AFTER_SERVICE}" ] || DNS_READY=1
 	[ "${DNS_READY:-1}" = 1 ]
 }


### PR DESCRIPTION
### Motivation

- Ensure the tzdata update workflow runs on pushes to main development and release branches and only triggers when its workflow file changes.
- Use a closer Arch Linux ARM mirror for downloads to improve reliability.
- Make the DNS test probe deterministic on CI by avoiding background `sleep` processes that can be orphaned on termination.

### Description

- Added a `push` trigger to `.github/workflows/update-tzdata.yml` for `master`, `main`, `dev`, `dev/**`, and version-tag branches and limited path filtering to the workflow file.
- Changed the workflow display name to `Update Tz-data packages` and updated the `MIRROR_URL` from `https://mirror.archlinuxarm.org` to `https://de.mirror.archlinuxarm.org`.
- Modified `tests/installer-dns-environment-failure.sh` to replace a fixed `sleep` with a busy-loop when `BLOCKING_QUERY` is enabled and added a comment explaining the rationale to avoid orphaned `sleep` processes and timing-dependent assertions.

### Testing

- Ran the repository shell integration test `tests/installer-dns-environment-failure.sh` after the change and observed the test complete successfully.
- Validated the workflow YAML with a standard linter for GitHub Actions and it passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8cc991cf788329ae92832ce630458f)