### PR TITLE
Extract tzdata download logic to script, update workflow triggers, and improve DNS test blocking

### DIFF
--- a/.github/workflows/update-tzdata.yml
+++ b/.github/workflows/update-tzdata.yml
@@ -1,6 +1,16 @@
-name: Update tzdata packages
+name: Update Tz-data packages
 
 on:
+  push:
+    branches:
+      - master
+      - main
+      - dev
+      - 'dev/**'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+    paths:
+      - .github/workflows/update-tzdata.yml
+      - tools/update-tzdata.sh
   schedule:
     - cron: '23 4 * * 1'
   workflow_dispatch:
@@ -62,177 +72,15 @@ jobs:
           persist-credentials: true
 
       - name: Download current packages
-        shell: bash
         env:
-          MIRROR_URL: https://mirror.archlinuxarm.org
+          CURL_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
+          MIRROR_HOSTS: >-
+            mirror.archlinuxarm.org
+            de.mirror.archlinuxarm.org
+            eu.mirror.archlinuxarm.org
+          PYTHON3: /usr/bin/python3
           SIGNING_KEY_FINGERPRINT: 68B3537F39A313B3E574D06777193F152BDBE6A6
-        run: |
-          set -euo pipefail
-
-          stage_dir="$(mktemp -d)"
-          trap 'rm -rf "${stage_dir}"' EXIT
-          export GNUPGHOME="${stage_dir}/gnupg"
-          mkdir -m 700 "${GNUPGHOME}"
-
-          gpg --batch --keyserver hkps://keyserver.ubuntu.com \
-            --keyserver-options timeout=30 \
-            --recv-keys "${SIGNING_KEY_FINGERPRINT}"
-          imported_fingerprint="$(gpg --batch --with-colons --fingerprint "${SIGNING_KEY_FINGERPRINT}" |
-            awk -F: '$1 == "fpr" { print $10; exit }')"
-          if [ "${imported_fingerprint}" != "${SIGNING_KEY_FINGERPRINT}" ]; then
-            printf 'Unexpected Arch Linux ARM signing-key fingerprint: %s\n' "${imported_fingerprint}" >&2
-            exit 1
-          fi
-
-          verify_signature() {
-            local signed_file signature_file valid_signature
-            signed_file="$1"
-            signature_file="$2"
-            valid_signature="$(gpg --batch --status-fd 1 --verify "${signature_file}" "${signed_file}" 2>/dev/null |
-              awk -v fingerprint="${SIGNING_KEY_FINGERPRINT}" \
-                '$1 == "[GNUPG:]" && $2 == "VALIDSIG" && ($3 == fingerprint || $NF == fingerprint) { print $3; exit }')"
-            if [ -z "${valid_signature}" ]; then
-              printf 'Signature verification failed for %s\n' "${signed_file}" >&2
-              return 1
-            fi
-          }
-
-          download_package() {
-            local architecture output_arch database database_signature description filename package_url
-            local upstream_file upstream_signature package_info package_version package_arch output_file
-            architecture="$1"
-            output_arch="$2"
-            database="${stage_dir}/core-${architecture}.db"
-
-            curl --fail --location --silent --show-error \
-              --proto '=https' --proto-redir '=https' \
-              --connect-timeout 15 --max-time 120 \
-              "${MIRROR_URL}/${architecture}/core/core.db" \
-              --output "${database}"
-            database_signature="${database}.sig"
-            curl --fail --location --silent --show-error \
-              --proto '=https' --proto-redir '=https' \
-              --connect-timeout 15 --max-time 120 \
-              "${MIRROR_URL}/${architecture}/core/core.db.sig" \
-              --output "${database_signature}"
-            verify_signature "${database}" "${database_signature}"
-
-            description="$(tar --wildcards -xOf "${database}" 'tzdata-*/desc')"
-            filename="$(printf '%s\n' "${description}" | awk '$0 == "%FILENAME%" { getline; print; exit }')"
-            case "${filename}" in
-              tzdata-*.pkg.tar.bz2|tzdata-*.pkg.tar.xz|tzdata-*.pkg.tar.zst) ;;
-              *)
-                printf 'Unexpected tzdata filename for %s: %s\n' "${architecture}" "${filename}" >&2
-                return 1
-                ;;
-            esac
-            if [ "${filename}" != "$(basename "${filename}")" ]; then
-              printf 'Filename contains path separators: %s\n' "${filename}" >&2
-              return 1
-            fi
-
-            package_url="${MIRROR_URL}/${architecture}/core/${filename}"
-            upstream_file="${stage_dir}/upstream-${architecture}.${filename##*.}"
-            upstream_signature="${upstream_file}.sig"
-            curl --fail --location --silent --show-error \
-              --proto '=https' --proto-redir '=https' \
-              --connect-timeout 15 --max-time 300 \
-              "${package_url}" --output "${upstream_file}"
-            curl --fail --location --silent --show-error \
-              --proto '=https' --proto-redir '=https' \
-              --connect-timeout 15 --max-time 120 \
-              "${package_url}.sig" --output "${upstream_signature}"
-            verify_signature "${upstream_file}" "${upstream_signature}"
-
-            if ! package_info="$(tar -xOf "${upstream_file}" ./.PKGINFO 2>/dev/null)"; then
-              printf 'Failed to extract .PKGINFO from %s\n' "${upstream_file}" >&2
-              return 1
-            fi
-            package_version="$(printf '%s\n' "${package_info}" | awk -F ' = ' '$1 == "pkgver" { print $2; exit }')"
-            package_arch="$(printf '%s\n' "${package_info}" | awk -F ' = ' '$1 == "arch" { print $2; exit }')"
-            if [ -z "${package_version}" ] || [ -z "${package_arch}" ]; then
-              printf 'Failed to extract version or architecture from .PKGINFO\n' >&2
-              return 1
-            fi
-            case "${package_version}" in
-              ''|*[!A-Za-z0-9._+-]*) return 1 ;;
-            esac
-            case "${package_arch}:${architecture}" in
-              aarch64:aarch64|armv7h:armv7h|any:*) ;;
-              *)
-                printf 'Package architecture mismatch: %s for %s\n' "${package_arch}" "${architecture}" >&2
-                return 1
-                ;;
-            esac
-
-            output_file="${stage_dir}/tzdata-${package_version}-${output_arch}.pkg.tar.bz2"
-            case "${upstream_file}" in
-              *.bz2) cp "${upstream_file}" "${output_file}" ;;
-              *.xz) xz --decompress --stdout "${upstream_file}" | bzip2 -9 >"${output_file}" ;;
-              *.zst) zstd --decompress --stdout "${upstream_file}" | bzip2 -9 >"${output_file}" ;;
-            esac
-            tar -tjf "${output_file}" >/dev/null
-            if ! tar -tjf "${output_file}" |
-              awk '/^\.\/usr\/share\/zoneinfo\/posix\/./ && !/\/$/ { found = 1 } END { exit !found }'; then
-              printf 'Package has no usable ./usr/share/zoneinfo/posix payload: %s\n' "${filename}" >&2
-              return 1
-            fi
-            python3 - "${output_file}" <<'PY'
-          import posixpath
-          import sys
-          import tarfile
-
-          archive = sys.argv[1]
-          with tarfile.open(archive, "r:bz2") as package:
-              for member in package.getmembers():
-                  normalized_name = posixpath.normpath(member.name)
-                  if member.name.startswith("/") or normalized_name == ".." or normalized_name.startswith("../"):
-                      raise SystemExit(f"Unsafe archive member path: {member.name}")
-                  if member.issym() or member.islnk():
-                      link_path = posixpath.normpath(posixpath.join(posixpath.dirname(normalized_name), member.linkname))
-                      if member.linkname.startswith("/") or link_path == ".." or link_path.startswith("../"):
-                          raise SystemExit(f"Unsafe archive link: {member.name} -> {member.linkname}")
-          PY
-            printf '%s\n' "${package_version}" >"${stage_dir}/version-${output_arch}"
-          }
-
-          download_package aarch64 aarch64
-          download_package armv7h arm
-
-          aarch64_version="$(cat "${stage_dir}/version-aarch64")"
-          arm_version="$(cat "${stage_dir}/version-arm")"
-          if [ "${aarch64_version}" != "${arm_version}" ]; then
-            printf 'tzdata versions differ: aarch64=%s arm=%s\n' "${aarch64_version}" "${arm_version}" >&2
-            exit 1
-          fi
-
-          # These globs intentionally remove every superseded package and sidecar.
-          rm -f tzdata-*-aarch64.pkg.tar.bz2 tzdata-*-aarch64.pkg.tar.bz2.md5sum tzdata-*-aarch64.pkg.tar.bz2.sha256sum
-          rm -f tzdata-*-arm.pkg.tar.bz2 tzdata-*-arm.pkg.tar.bz2.md5sum tzdata-*-arm.pkg.tar.bz2.sha256sum
-          if [ ! -f "${stage_dir}/tzdata-${aarch64_version}-aarch64.pkg.tar.bz2" ]; then
-            printf 'aarch64 package file not found\n' >&2
-            exit 1
-          fi
-          if [ ! -f "${stage_dir}/tzdata-${arm_version}-arm.pkg.tar.bz2" ]; then
-            printf 'arm package file not found\n' >&2
-            exit 1
-          fi
-          mv "${stage_dir}/tzdata-${aarch64_version}-aarch64.pkg.tar.bz2" .
-          mv "${stage_dir}/tzdata-${arm_version}-arm.pkg.tar.bz2" .
-
-          if ! grep -Eq '^[[:space:]]*TZ_DATA="tzdata-[^"]*-\$\{TZ_ARCH\}\.pkg\.tar\.bz2"$' installer; then
-            printf 'Expected TZ_DATA assignment not found in installer\n' >&2
-            exit 1
-          fi
-          sed -i "s/TZ_DATA=\"tzdata-[^\"]*-\${TZ_ARCH}\.pkg\.tar\.bz2\"/TZ_DATA=\"tzdata-${aarch64_version}-\${TZ_ARCH}.pkg.tar.bz2\"/" installer
-          if ! grep -Fq "TZ_DATA=\"tzdata-${aarch64_version}-\${TZ_ARCH}.pkg.tar.bz2\"" installer; then
-            printf 'Failed to update TZ_DATA in installer\n' >&2
-            exit 1
-          fi
-          sh tools/update-checksums.sh \
-            "tzdata-${aarch64_version}-aarch64.pkg.tar.bz2" \
-            "tzdata-${arm_version}-arm.pkg.tar.bz2" \
-            installer
+        run: sh tools/update-tzdata.sh .
 
       - name: Commit package updates
         shell: bash

--- a/tests/installer-dns-environment-failure.sh
+++ b/tests/installer-dns-environment-failure.sh
@@ -22,6 +22,7 @@ cleanup() { rm -rf "${TEST_ROOT}"; }
 trap cleanup 0
 trap 'cleanup; exit 1' HUP INT TERM
 mkdir -p "${TEST_ROOT}" || fail 'could not create test workspace'
+mkfifo "${TEST_ROOT}/block.fifo" || fail 'could not create blocking DNS query FIFO'
 
 : >"${FUNCTIONS_FILE}" || fail 'could not create test functions file'
 sed -n '/^nvram_transaction_begin() {$/,/^installer_lan_domain_set() {$/p' "${INSTALLER_PATH}" |
@@ -289,7 +290,11 @@ nslookup() {
 	if [ "${TRACK_LOOKUP:-0}" = 1 ]; then
 		trap 'printf "%s\n" reaped >"${TEST_ROOT}/lookup-reaped"; exit 1' TERM
 	fi
-	[ "${BLOCKING_QUERY:-0}" = 0 ] || /bin/sleep 5
+	# Block without an external child process or a CPU-burning loop until the
+	# deadline logic terminates the probe.
+	if [ "${BLOCKING_QUERY:-0}" != 0 ]; then
+		read -r _blocked_lookup <"${TEST_ROOT}/block.fifo" || :
+	fi
 	[ "${DNS_READY_AFTER_SERVICE:-0}" -eq 0 ] || [ "${SERVICE_COUNT}" -lt "${DNS_READY_AFTER_SERVICE}" ] || DNS_READY=1
 	[ "${DNS_READY:-1}" = 1 ]
 }

--- a/tools/update-tzdata.sh
+++ b/tools/update-tzdata.sh
@@ -1,0 +1,210 @@
+#!/bin/sh
+# Download and publish current signed Arch Linux ARM tzdata packages.
+# POSIX /bin/sh-compatible; intended for CI validation hosts.
+
+set -eu
+
+OUT_DIR="${1:-.}"
+: "${CURL_CA_BUNDLE:?CURL_CA_BUNDLE is required}"
+: "${MIRROR_HOSTS:?MIRROR_HOSTS is required}"
+: "${PYTHON3:?PYTHON3 is required}"
+: "${SIGNING_KEY_FINGERPRINT:?SIGNING_KEY_FINGERPRINT is required}"
+
+if [ ! -r "${CURL_CA_BUNDLE}" ]; then
+	printf 'Certificate authority bundle is not readable: %s\n' "${CURL_CA_BUNDLE}" >&2
+	exit 1
+fi
+if [ "${PYTHON3}" != /usr/bin/python3 ] || [ ! -x "${PYTHON3}" ]; then
+	printf 'Trusted Python 3 interpreter is unavailable: %s\n' "${PYTHON3}" >&2
+	exit 1
+fi
+
+cd "${OUT_DIR}" || exit 1
+
+stage_dir="$(mktemp -d)"
+trap 'rm -rf "${stage_dir}"' 0
+export GNUPGHOME="${stage_dir}/gnupg"
+mkdir -m 700 "${GNUPGHOME}"
+
+gpg --batch --keyserver hkps://keyserver.ubuntu.com \
+	--keyserver-options timeout=30 \
+	--recv-keys "${SIGNING_KEY_FINGERPRINT}"
+imported_fingerprint="$(gpg --batch --with-colons --fingerprint "${SIGNING_KEY_FINGERPRINT}" |
+	awk -F: '$1 == "fpr" { print $10; exit }')"
+if [ "${imported_fingerprint}" != "${SIGNING_KEY_FINGERPRINT}" ]; then
+	printf 'Unexpected Arch Linux ARM signing-key fingerprint: %s\n' "${imported_fingerprint}" >&2
+	exit 1
+fi
+
+verify_signature() {
+	local signed_file signature_file valid_signature
+	signed_file="$1"
+	signature_file="$2"
+	valid_signature="$(gpg --batch --status-fd 1 --verify "${signature_file}" "${signed_file}" 2>/dev/null |
+		awk -v fingerprint="${SIGNING_KEY_FINGERPRINT}" \
+			'$1 == "[GNUPG:]" && $2 == "VALIDSIG" && ($3 == fingerprint || $NF == fingerprint) { print $3; exit }')"
+	if [ -z "${valid_signature}" ]; then
+		printf 'Signature verification failed for %s\n' "${signed_file}" >&2
+		return 1
+	fi
+}
+
+download_verified_pair() {
+	local max_time mirror_host mirror_url output_file protocol redirect_protocols relative_path signature_file
+	relative_path="$1"
+	output_file="$2"
+	max_time="$3"
+	signature_file="${output_file}.sig"
+
+	# MIRROR_HOSTS is a trusted, whitespace-separated workflow setting. Try all
+	# TLS endpoints before the signed HTTP fallback, and authenticate every pair
+	# before consuming it.
+	for protocol in https http; do
+		redirect_protocols="=${protocol}"
+		[ "${protocol}" != http ] || redirect_protocols='=http,https'
+		for mirror_host in ${MIRROR_HOSTS}; do
+			mirror_url="${protocol}://${mirror_host}"
+			rm -f "${output_file}" "${signature_file}"
+			printf 'Downloading %s from %s\n' "${relative_path}" "${mirror_url}"
+			if curl --fail --location --silent --show-error \
+				--cacert "${CURL_CA_BUNDLE}" \
+				--proto "=${protocol}" --proto-redir "${redirect_protocols}" \
+				--connect-timeout 15 --max-time "${max_time}" \
+				"${mirror_url}/${relative_path}" --output "${output_file}" &&
+				curl --fail --location --silent --show-error \
+					--cacert "${CURL_CA_BUNDLE}" \
+					--proto "=${protocol}" --proto-redir "${redirect_protocols}" \
+					--connect-timeout 15 --max-time 120 \
+					"${mirror_url}/${relative_path}.sig" --output "${signature_file}" &&
+				verify_signature "${output_file}" "${signature_file}"; then
+				return 0
+			fi
+			printf 'Mirror failed verification or download: %s\n' "${mirror_url}" >&2
+		done
+	done
+
+	rm -f "${output_file}" "${signature_file}"
+	printf 'No mirror supplied a verified copy of %s\n' "${relative_path}" >&2
+	return 1
+}
+
+download_package() {
+	local architecture output_arch database description filename
+	local upstream_file package_info package_version package_arch output_file
+	architecture="$1"
+	output_arch="$2"
+	database="${stage_dir}/core-${architecture}.db"
+
+	download_verified_pair "${architecture}/core/core.db" "${database}" 120
+
+	description="$(tar --wildcards -xOf "${database}" 'tzdata-*/desc')"
+	filename="$(printf '%s\n' "${description}" | awk '$0 == "%FILENAME%" { getline; print; exit }')"
+	case "${filename}" in
+		tzdata-*.pkg.tar.bz2|tzdata-*.pkg.tar.xz|tzdata-*.pkg.tar.zst) ;;
+		*)
+			printf 'Unexpected tzdata filename for %s: %s\n' "${architecture}" "${filename}" >&2
+			return 1
+			;;
+	esac
+	if [ "${filename}" != "$(basename "${filename}")" ]; then
+		printf 'Filename contains path separators: %s\n' "${filename}" >&2
+		return 1
+	fi
+
+	upstream_file="${stage_dir}/upstream-${architecture}.${filename##*.}"
+	download_verified_pair "${architecture}/core/${filename}" "${upstream_file}" 300
+
+	if ! package_info="$(tar -xOf "${upstream_file}" ./.PKGINFO 2>/dev/null)"; then
+		printf 'Failed to extract .PKGINFO from %s\n' "${upstream_file}" >&2
+		return 1
+	fi
+	package_version="$(printf '%s\n' "${package_info}" | awk -F ' = ' '$1 == "pkgver" { print $2; exit }')"
+	package_arch="$(printf '%s\n' "${package_info}" | awk -F ' = ' '$1 == "arch" { print $2; exit }')"
+	if [ -z "${package_version}" ] || [ -z "${package_arch}" ]; then
+		printf 'Failed to extract version or architecture from .PKGINFO\n' >&2
+		return 1
+	fi
+	case "${package_version}" in
+		''|*[!A-Za-z0-9._+-]*) return 1 ;;
+		*) : ;;
+	esac
+	case "${package_arch}:${architecture}" in
+		aarch64:aarch64|armv7h:armv7h|any:*) ;;
+		*)
+			printf 'Package architecture mismatch: %s for %s\n' "${package_arch}" "${architecture}" >&2
+			return 1
+			;;
+	esac
+
+	output_file="${stage_dir}/tzdata-${package_version}-${output_arch}.pkg.tar.bz2"
+	case "${upstream_file}" in
+		*.bz2) cp "${upstream_file}" "${output_file}" ;;
+		*.xz) xz --decompress --stdout "${upstream_file}" | bzip2 -9 >"${output_file}" ;;
+		*.zst) zstd --decompress --stdout "${upstream_file}" | bzip2 -9 >"${output_file}" ;;
+		*)
+			printf 'Unsupported tzdata package compression: %s\n' "${upstream_file}" >&2
+			return 1
+			;;
+	esac
+	tar -tjf "${output_file}" >/dev/null
+	if ! tar -tjf "${output_file}" |
+		awk '/^\.\/usr\/share\/zoneinfo\/posix\/./ && !/\/$/ { found = 1 } END { exit !found }'; then
+		printf 'Package has no usable ./usr/share/zoneinfo/posix payload: %s\n' "${filename}" >&2
+		return 1
+	fi
+	"${PYTHON3}" - "${output_file}" <<'PY'
+import posixpath
+import sys
+import tarfile
+
+archive = sys.argv[1]
+with tarfile.open(archive, "r:bz2") as package:
+    for member in package.getmembers():
+        normalized_name = posixpath.normpath(member.name)
+        if member.name.startswith("/") or normalized_name == ".." or normalized_name.startswith("../"):
+            raise SystemExit(f"Unsafe archive member path: {member.name}")
+        if member.issym() or member.islnk():
+            link_path = posixpath.normpath(posixpath.join(posixpath.dirname(normalized_name), member.linkname))
+            if member.linkname.startswith("/") or link_path == ".." or link_path.startswith("../"):
+                raise SystemExit(f"Unsafe archive link: {member.name} -> {member.linkname}")
+PY
+	printf '%s\n' "${package_version}" >"${stage_dir}/version-${output_arch}"
+}
+
+download_package aarch64 aarch64
+download_package armv7h arm
+
+aarch64_version="$(cat "${stage_dir}/version-aarch64")"
+arm_version="$(cat "${stage_dir}/version-arm")"
+if [ "${aarch64_version}" != "${arm_version}" ]; then
+	printf 'tzdata versions differ: aarch64=%s arm=%s\n' "${aarch64_version}" "${arm_version}" >&2
+	exit 1
+fi
+
+# These globs intentionally remove every superseded package and sidecar.
+rm -f tzdata-*-aarch64.pkg.tar.bz2 tzdata-*-aarch64.pkg.tar.bz2.md5sum tzdata-*-aarch64.pkg.tar.bz2.sha256sum
+rm -f tzdata-*-arm.pkg.tar.bz2 tzdata-*-arm.pkg.tar.bz2.md5sum tzdata-*-arm.pkg.tar.bz2.sha256sum
+if [ ! -f "${stage_dir}/tzdata-${aarch64_version}-aarch64.pkg.tar.bz2" ]; then
+	printf 'aarch64 package file not found\n' >&2
+	exit 1
+fi
+if [ ! -f "${stage_dir}/tzdata-${arm_version}-arm.pkg.tar.bz2" ]; then
+	printf 'arm package file not found\n' >&2
+	exit 1
+fi
+mv "${stage_dir}/tzdata-${aarch64_version}-aarch64.pkg.tar.bz2" .
+mv "${stage_dir}/tzdata-${arm_version}-arm.pkg.tar.bz2" .
+
+if ! grep -Eq '^[[:space:]]*TZ_DATA="tzdata-[^"]*-\$\{TZ_ARCH\}\.pkg\.tar\.bz2"$' installer; then
+	printf 'Expected TZ_DATA assignment not found in installer\n' >&2
+	exit 1
+fi
+sed -i "s/TZ_DATA=\"tzdata-[^\"]*-\${TZ_ARCH}\.pkg\.tar\.bz2\"/TZ_DATA=\"tzdata-${aarch64_version}-\${TZ_ARCH}.pkg.tar.bz2\"/" installer
+if ! grep -Fq "TZ_DATA=\"tzdata-${aarch64_version}-\${TZ_ARCH}.pkg.tar.bz2\"" installer; then
+	printf 'Failed to update TZ_DATA in installer\n' >&2
+	exit 1
+fi
+sh tools/update-checksums.sh \
+	"tzdata-${aarch64_version}-aarch64.pkg.tar.bz2" \
+	"tzdata-${arm_version}-arm.pkg.tar.bz2" \
+	installer


### PR DESCRIPTION
### Motivation

- Factor the large inline package-download and verification logic out of the GitHub Actions workflow into a reusable, testable script. 
- Make the tzdata updater workflow trigger on pushes to main development branches and specific tags, and harden mirror/CA handling for CI hosts. 
- Improve the DNS environment failure test to block deterministically using a FIFO instead of sleeping, enabling controlled probe termination testing.

### Description

- Reworked `.github/workflows/update-tzdata.yml` to add push triggers for `master`, `main`, `dev`, `dev/**` and version tags, expose `CURL_CA_BUNDLE`, `MIRROR_HOSTS` and `PYTHON3` environment variables, and replace the large inline download step with `sh tools/update-tzdata.sh .`.
- Added `tools/update-tzdata.sh`, a POSIX `/bin/sh` script that imports the Arch Linux ARM signing key, iterates configured `MIRROR_HOSTS` over HTTPS/HTTP to download and verify `core.db` and tzdata package pairs, validates package contents and archive safety, converts supported compressions to bzip2, updates the `installer` file and calls `tools/update-checksums.sh`.
- Modified `tests/installer-dns-environment-failure.sh` to create a blocking FIFO in the test workspace and change the `nslookup()` helper to block by reading from that FIFO when `BLOCKING_QUERY` is set, allowing tests to control when a DNS probe unblocks.

### Testing

- No automated tests were executed as part of this rollout; the change prepares the workflow and scripts for CI runs but no CI run results are included here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8cc991cf788329ae92832ce630458f)