### PR TITLE
update-tzdata: discover packages via package-index HTML, add `PACKAGE_INDEX_URL` and publish validation

### DIFF
--- a/.github/workflows/update-tzdata.yml
+++ b/.github/workflows/update-tzdata.yml
@@ -75,9 +75,11 @@ jobs:
         env:
           CURL_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
           MIRROR_HOSTS: >-
+            ca.us.mirror.archlinuxarm.org
+            nj.us.mirror.archlinuxarm.org
+            fl.us.mirror.archlinuxarm.org
             mirror.archlinuxarm.org
-            de.mirror.archlinuxarm.org
-            eu.mirror.archlinuxarm.org
+          PACKAGE_INDEX_URL: https://archlinuxarm.org/packages
           PYTHON3: /usr/bin/python3
           SIGNING_KEY_FINGERPRINT: 68B3537F39A313B3E574D06777193F152BDBE6A6
         run: sh tools/update-tzdata.sh .

--- a/tools/update-tzdata.sh
+++ b/tools/update-tzdata.sh
@@ -218,6 +218,13 @@ publish_package() {
 		printf 'Failed to publish package file: %s\n' "${published_file}" >&2
 		return 1
 	fi
+	if ! sh tools/update-checksums.sh "${published_file}" ||
+		[ ! -f "${published_file}.md5sum" ] ||
+		[ ! -f "${published_file}.sha256sum" ]; then
+		printf 'Failed to publish package checksums: %s\n' "${published_file}" >&2
+		rm -f "${published_file}" "${published_file}.md5sum" "${published_file}.sha256sum"
+		return 1
+	fi
 }
 
 # These globs intentionally remove every superseded package and sidecar.
@@ -236,6 +243,4 @@ if ! grep -Fq "TZ_DATA=\"tzdata-${aarch64_version}-\${TZ_ARCH}.pkg.tar.bz2\"" in
 	exit 1
 fi
 sh tools/update-checksums.sh \
-	"tzdata-${aarch64_version}-aarch64.pkg.tar.bz2" \
-	"tzdata-${arm_version}-arm.pkg.tar.bz2" \
 	installer

--- a/tools/update-tzdata.sh
+++ b/tools/update-tzdata.sh
@@ -7,6 +7,7 @@ set -eu
 OUT_DIR="${1:-.}"
 : "${CURL_CA_BUNDLE:?CURL_CA_BUNDLE is required}"
 : "${MIRROR_HOSTS:?MIRROR_HOSTS is required}"
+: "${PACKAGE_INDEX_URL:?PACKAGE_INDEX_URL is required}"
 : "${PYTHON3:?PYTHON3 is required}"
 : "${SIGNING_KEY_FINGERPRINT:?SIGNING_KEY_FINGERPRINT is required}"
 
@@ -88,24 +89,45 @@ download_verified_pair() {
 	return 1
 }
 
-download_package() {
-	local architecture output_arch database description filename
-	local upstream_file package_info package_version package_arch output_file
+discover_package_filename() {
+	local architecture package_page filename
 	architecture="$1"
-	output_arch="$2"
-	database="${stage_dir}/core-${architecture}.db"
+	package_page="${stage_dir}/package-${architecture}.html"
 
-	download_verified_pair "${architecture}/core/core.db" "${database}" 120
-
-	description="$(tar --wildcards -xOf "${database}" 'tzdata-*/desc')"
-	filename="$(printf '%s\n' "${description}" | awk '$0 == "%FILENAME%" { getline; print; exit }')"
+	case "${PACKAGE_INDEX_URL}" in
+		https://archlinuxarm.org/packages) ;;
+		*)
+			printf 'Unexpected Arch Linux ARM package index URL: %s\n' "${PACKAGE_INDEX_URL}" >&2
+			return 1
+			;;
+	esac
+	if ! curl --fail --location --silent --show-error \
+		--cacert "${CURL_CA_BUNDLE}" \
+		--proto '=https' --proto-redir '=https' \
+		--connect-timeout 15 --max-time 120 \
+		"${PACKAGE_INDEX_URL}/${architecture}/tzdata" --output "${package_page}"; then
+		printf 'Failed to download tzdata package page for %s\n' "${architecture}" >&2
+		return 1
+	fi
+	filename="$(grep -Eo "tzdata-[A-Za-z0-9._+-]+-${architecture}\\.pkg\\.tar\\.(bz2|xz|zst)" "${package_page}" |
+		head -n 1)"
 	case "${filename}" in
-		tzdata-*.pkg.tar.bz2 | tzdata-*.pkg.tar.xz | tzdata-*.pkg.tar.zst) ;;
+		tzdata-*-${architecture}.pkg.tar.bz2 | tzdata-*-${architecture}.pkg.tar.xz | tzdata-*-${architecture}.pkg.tar.zst)
+			printf '%s\n' "${filename}"
+			;;
 		*)
 			printf 'Unexpected tzdata filename for %s: %s\n' "${architecture}" "${filename}" >&2
 			return 1
 			;;
 	esac
+}
+
+download_package() {
+	local architecture output_arch filename
+	local upstream_file package_info package_version package_arch output_file
+	architecture="$1"
+	output_arch="$2"
+	filename="$(discover_package_filename "${architecture}")"
 	if [ "${filename}" != "$(basename "${filename}")" ]; then
 		printf 'Filename contains path separators: %s\n' "${filename}" >&2
 		return 1
@@ -176,19 +198,33 @@ if [ "${aarch64_version}" != "${arm_version}" ]; then
 	exit 1
 fi
 
+publish_package() {
+	local output_arch package_version published_file staged_file
+	output_arch="$1"
+	package_version="$2"
+	published_file="tzdata-${package_version}-${output_arch}.pkg.tar.bz2"
+	staged_file="${stage_dir}/${published_file}"
+
+	if [ ! -f "${staged_file}" ]; then
+		printf '%s package file not found: %s\n' "${output_arch}" "${staged_file}" >&2
+		return 1
+	fi
+	if ! tar -tjf "${staged_file}" >/dev/null; then
+		printf 'Invalid bzip2 package archive: %s\n' "${staged_file}" >&2
+		return 1
+	fi
+	mv "${staged_file}" "${published_file}"
+	if [ ! -f "${published_file}" ]; then
+		printf 'Failed to publish package file: %s\n' "${published_file}" >&2
+		return 1
+	fi
+}
+
 # These globs intentionally remove every superseded package and sidecar.
 rm -f tzdata-*-aarch64.pkg.tar.bz2 tzdata-*-aarch64.pkg.tar.bz2.md5sum tzdata-*-aarch64.pkg.tar.bz2.sha256sum
 rm -f tzdata-*-arm.pkg.tar.bz2 tzdata-*-arm.pkg.tar.bz2.md5sum tzdata-*-arm.pkg.tar.bz2.sha256sum
-if [ ! -f "${stage_dir}/tzdata-${aarch64_version}-aarch64.pkg.tar.bz2" ]; then
-	printf 'aarch64 package file not found\n' >&2
-	exit 1
-fi
-if [ ! -f "${stage_dir}/tzdata-${arm_version}-arm.pkg.tar.bz2" ]; then
-	printf 'arm package file not found\n' >&2
-	exit 1
-fi
-mv "${stage_dir}/tzdata-${aarch64_version}-aarch64.pkg.tar.bz2" .
-mv "${stage_dir}/tzdata-${arm_version}-arm.pkg.tar.bz2" .
+publish_package aarch64 "${aarch64_version}"
+publish_package arm "${arm_version}"
 
 if ! grep -Eq '^[[:space:]]*TZ_DATA="tzdata-[^"]*-\$\{TZ_ARCH\}\.pkg\.tar\.bz2"$' installer; then
 	printf 'Expected TZ_DATA assignment not found in installer\n' >&2

--- a/tools/update-tzdata.sh
+++ b/tools/update-tzdata.sh
@@ -109,10 +109,10 @@ discover_package_filename() {
 		printf 'Failed to download tzdata package page for %s\n' "${architecture}" >&2
 		return 1
 	fi
-	filename="$(grep -Eo "tzdata-[A-Za-z0-9._+-]+-${architecture}\\.pkg\\.tar\\.(bz2|xz|zst)" "${package_page}" |
+	filename="$(grep -Eo "tzdata-[A-Za-z0-9._+-]+-(any|${architecture})\\.pkg\\.tar\\.(bz2|xz|zst)" "${package_page}" |
 		head -n 1)"
 	case "${filename}" in
-		tzdata-*-${architecture}.pkg.tar.bz2 | tzdata-*-${architecture}.pkg.tar.xz | tzdata-*-${architecture}.pkg.tar.zst)
+		tzdata-*-any.pkg.tar.bz2 | tzdata-*-any.pkg.tar.xz | tzdata-*-any.pkg.tar.zst | tzdata-*-${architecture}.pkg.tar.bz2 | tzdata-*-${architecture}.pkg.tar.xz | tzdata-*-${architecture}.pkg.tar.zst)
 			printf '%s\n' "${filename}"
 			;;
 		*)

--- a/tools/update-tzdata.sh
+++ b/tools/update-tzdata.sh
@@ -127,7 +127,10 @@ download_package() {
 	local upstream_file package_info package_version package_arch output_file
 	architecture="$1"
 	output_arch="$2"
-	filename="$(discover_package_filename "${architecture}")"
+	if ! filename="$(discover_package_filename "${architecture}")" || [ -z "${filename}" ]; then
+		printf 'Failed to discover package filename for %s\n' "${architecture}" >&2
+		return 1
+	fi
 	if [ "${filename}" != "$(basename "${filename}")" ]; then
 		printf 'Filename contains path separators: %s\n' "${filename}" >&2
 		return 1

--- a/tools/update-tzdata.sh
+++ b/tools/update-tzdata.sh
@@ -105,7 +105,7 @@ discover_package_filename() {
 		--cacert "${CURL_CA_BUNDLE}" \
 		--proto '=https' --proto-redir '=https' \
 		--connect-timeout 15 --max-time 120 \
-		"${PACKAGE_INDEX_URL}/${architecture}/tzdata" --output "${package_page}"; then
+		"${PACKAGE_INDEX_URL}/any/tzdata" --output "${package_page}"; then
 		printf 'Failed to download tzdata package page for %s\n' "${architecture}" >&2
 		return 1
 	fi


### PR DESCRIPTION
### Motivation

- Replace the previous approach of reading `core.db` with a more robust discovery of the published tzdata package filename from the Arch Linux ARM package index HTML and centralize the package index URL.
- Improve integrity checks and publishing steps to ensure staged tzdata package files are valid before they are moved into the repository.
- Adjust CI workflow mirrors and expose the `PACKAGE_INDEX_URL` environment variable for the updated discovery logic.

### Description

- Require a new environment variable `PACKAGE_INDEX_URL` in `tools/update-tzdata.sh` and validate it only allows `https://archlinuxarm.org/packages`.
- Add `discover_package_filename()` which downloads the package HTML page and extracts the `tzdata` package filename using `curl` and `grep` instead of parsing `core.db` content. 
- Refactor `download_package()` to call `discover_package_filename()` and continue to verify and extract `.PKGINFO` to obtain version and architecture.
- Add `publish_package()` to validate staged package archives with `tar -tjf` and move them into place, replacing direct `mv` checks; and update the workflow to supply `PACKAGE_INDEX_URL` and adjust mirror hosts.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8cfb8acd288329ac4cad0a65b080fe)