### PR TITLE
Fix tzdata package discovery (mirror-based) and update workflow checkout pin

### DIFF
--- a/.github/workflows/update-tzdata.yml
+++ b/.github/workflows/update-tzdata.yml
@@ -65,7 +65,7 @@ jobs:
           printf 'target=%s\n' "${target_branch}" >>"${GITHUB_OUTPUT}"
 
       - name: Checkout target branch
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           ref: ${{ steps.branch.outputs.target }}
           fetch-depth: 0
@@ -79,7 +79,6 @@ jobs:
             nj.us.mirror.archlinuxarm.org
             fl.us.mirror.archlinuxarm.org
             mirror.archlinuxarm.org
-          PACKAGE_INDEX_URL: https://archlinuxarm.org/packages
           PYTHON3: /usr/bin/python3
           SIGNING_KEY_FINGERPRINT: 68B3537F39A313B3E574D06777193F152BDBE6A6
         run: sh tools/update-tzdata.sh .

--- a/tools/update-tzdata.sh
+++ b/tools/update-tzdata.sh
@@ -7,7 +7,6 @@ set -eu
 OUT_DIR="${1:-.}"
 : "${CURL_CA_BUNDLE:?CURL_CA_BUNDLE is required}"
 : "${MIRROR_HOSTS:?MIRROR_HOSTS is required}"
-: "${PACKAGE_INDEX_URL:?PACKAGE_INDEX_URL is required}"
 : "${PYTHON3:?PYTHON3 is required}"
 : "${SIGNING_KEY_FINGERPRINT:?SIGNING_KEY_FINGERPRINT is required}"
 
@@ -90,36 +89,40 @@ download_verified_pair() {
 }
 
 discover_package_filename() {
-	local architecture package_page filename
+	local architecture filename mirror_host mirror_url package_listing protocol redirect_protocols
 	architecture="$1"
-	package_page="${stage_dir}/package-${architecture}.html"
+	package_listing="${stage_dir}/package-${architecture}.html"
 
-	case "${PACKAGE_INDEX_URL}" in
-		https://archlinuxarm.org/packages) ;;
-		*)
-			printf 'Unexpected Arch Linux ARM package index URL: %s\n' "${PACKAGE_INDEX_URL}" >&2
-			return 1
-			;;
-	esac
-	if ! curl --fail --location --silent --show-error \
-		--cacert "${CURL_CA_BUNDLE}" \
-		--proto '=https' --proto-redir '=https' \
-		--connect-timeout 15 --max-time 120 \
-		"${PACKAGE_INDEX_URL}/any/tzdata" --output "${package_page}"; then
-		printf 'Failed to download tzdata package page for %s\n' "${architecture}" >&2
-		return 1
-	fi
-	filename="$(grep -Eo "tzdata-[A-Za-z0-9._+-]+-(any|${architecture})\\.pkg\\.tar\\.(bz2|xz|zst)" "${package_page}" |
-		head -n 1)"
-	case "${filename}" in
-		tzdata-*-any.pkg.tar.bz2 | tzdata-*-any.pkg.tar.xz | tzdata-*-any.pkg.tar.zst | tzdata-*-${architecture}.pkg.tar.bz2 | tzdata-*-${architecture}.pkg.tar.xz | tzdata-*-${architecture}.pkg.tar.zst)
-			printf '%s\n' "${filename}"
-			;;
-		*)
-			printf 'Unexpected tzdata filename for %s: %s\n' "${architecture}" "${filename}" >&2
-			return 1
-			;;
-	esac
+	# Discover the filename from the same mirrors that serve the package.  The
+	# public package-index pages are not a stable API and may return 404 even
+	# while the repository remains available.
+	for protocol in https http; do
+		redirect_protocols="=${protocol}"
+		[ "${protocol}" != http ] || redirect_protocols='=http,https'
+		for mirror_host in ${MIRROR_HOSTS}; do
+			mirror_url="${protocol}://${mirror_host}"
+			if ! curl --fail --location --silent --show-error \
+				--cacert "${CURL_CA_BUNDLE}" \
+				--proto "=${protocol}" --proto-redir "${redirect_protocols}" \
+				--connect-timeout 15 --max-time 120 \
+				"${mirror_url}/${architecture}/core/" --output "${package_listing}"; then
+				printf 'Failed to download package listing from %s\n' "${mirror_url}" >&2
+				continue
+			fi
+			filename="$(grep -Eo "tzdata-[A-Za-z0-9._+-]+-(any|${architecture})\\.pkg\\.tar\\.(bz2|xz|zst)" "${package_listing}" |
+				head -n 1)"
+			case "${filename}" in
+				tzdata-*-any.pkg.tar.bz2 | tzdata-*-any.pkg.tar.xz | tzdata-*-any.pkg.tar.zst | tzdata-*-${architecture}.pkg.tar.bz2 | tzdata-*-${architecture}.pkg.tar.xz | tzdata-*-${architecture}.pkg.tar.zst)
+					printf '%s\n' "${filename}"
+					return 0
+					;;
+			esac
+			printf 'No valid tzdata filename in package listing from %s\n' "${mirror_url}" >&2
+		done
+	done
+
+	printf 'Failed to discover package filename for %s from all mirrors\n' "${architecture}" >&2
+	return 1
 }
 
 download_package() {


### PR DESCRIPTION
### Motivation

- The `tools/update-tzdata.sh` CI tool was failing to discover tzdata package filenames because the Arch Linux ARM package-index page used previously returned 404s, causing the workflow to abort. 
- The workflow showed a Node deprecation warning tied to an older pinned `actions/checkout` revision, so the checkout action was upgraded to a current pinned revision to avoid runtime warnings.

### Description

- Replace package-index scraping with mirror-based discovery in `tools/update-tzdata.sh` by enumerating configured `MIRROR_HOSTS` and parsing each mirror's `/<arch>/core/` listing to find a matching `tzdata-...pkg.tar.*` filename. 
- Implement HTTPS-first mirror failover (TLS mirrors, then HTTP) while preserving signature verification via the existing GPG fingerprint check and the `download_verified_pair` logic. 
- Remove the `PACKAGE_INDEX_URL` required check from the script and stop passing that workflow environment variable, keeping the updater POSIX `/bin/sh` compatible and retaining the `/usr/bin/python3` validation used for archive safety checks. 
- Update `.github/workflows/update-tzdata.yml` to use the repository's pinned `actions/checkout` v5 revision and remove the now-unused `PACKAGE_INDEX_URL` environment entry.

### Testing

- Ran `git diff --check` with no whitespace/patch errors and `sh -n tools/update-tzdata.sh` for shell syntax which both succeeded. 
- Verified working-tree status with `git status --short --branch` and produced a local commit for the change. 
- `shellcheck -s sh` and `actionlint` were not available in the validation environment, so those checks were not executed. 
- Live end-to-end mirror validation (downloading listings and packages) was attempted but was blocked by the environment proxy returning HTTP 403, so full network verification could not be performed in this runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d184b8b9c8329b4441e62516733e5)