### PR TITLE
fix(update-tzdata): robustly extract .PKGINFO from tzdata package archives and add regression test

### DIFF
--- a/.github/workflows/shell-validation.yml
+++ b/.github/workflows/shell-validation.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Run checksum output validation regression
         run: /usr/bin/timeout --kill-after=10 180 busybox ash tests/static-checksum-output-validation.sh
 
+      - name: Run tzdata package metadata regression
+        run: /usr/bin/timeout --kill-after=10 180 busybox ash tests/update-tzdata-package-info.sh
+
       - name: Run installer jq dependency regression
         run: /usr/bin/timeout --kill-after=10 180 busybox ash tests/installer-jq-helper.sh
 

--- a/.github/workflows/update-tzdata.yml
+++ b/.github/workflows/update-tzdata.yml
@@ -10,6 +10,7 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
     paths:
       - .github/workflows/update-tzdata.yml
+      - tests/update-tzdata-package-info.sh
       - tools/tzdata-package-info.sh
       - tools/update-tzdata.sh
   schedule:
@@ -71,6 +72,9 @@ jobs:
           ref: ${{ steps.branch.outputs.target }}
           fetch-depth: 0
           persist-credentials: true
+
+      - name: Run tzdata package metadata regression
+        run: sh tests/update-tzdata-package-info.sh
 
       - name: Download current packages
         env:

--- a/.github/workflows/update-tzdata.yml
+++ b/.github/workflows/update-tzdata.yml
@@ -10,6 +10,7 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
     paths:
       - .github/workflows/update-tzdata.yml
+      - tools/tzdata-package-info.sh
       - tools/update-tzdata.sh
   schedule:
     - cron: '23 4 * * 1'

--- a/tests/coderabbit-and-workflow-config-checks.sh
+++ b/tests/coderabbit-and-workflow-config-checks.sh
@@ -228,6 +228,8 @@ grep -Fq '      - tools/tzdata-package-info.sh' "${TZDATA_WORKFLOW}" ||
 	fail "${TZDATA_WORKFLOW}: tzdata helper changes must trigger the update workflow"
 grep -Fq '        run: sh tests/update-tzdata-package-info.sh' "${TZDATA_WORKFLOW}" ||
 	fail "${TZDATA_WORKFLOW}: expected the tzdata metadata regression before package publication"
+grep -Fq "run_check 'tzdata package metadata regression' sh tests/update-tzdata-package-info.sh" "${LOCAL_QUALITY_RUNNER}" ||
+	fail "${LOCAL_QUALITY_RUNNER}: expected the tzdata metadata regression in the local and CI quality matrix"
 grep -Fq "run_check 'Installer jq dependency regression' sh tests/installer-jq-helper.sh" "${LOCAL_QUALITY_RUNNER}" ||
 	fail "${LOCAL_QUALITY_RUNNER}: expected the installer jq dependency regression in the local quality matrix"
 grep -Fq 'tests/installer-jq-helper.sh)' "${LOCAL_QUALITY_TEST}" ||

--- a/tests/coderabbit-and-workflow-config-checks.sh
+++ b/tests/coderabbit-and-workflow-config-checks.sh
@@ -12,6 +12,7 @@ CODEX_PROMPT='.github/prompts/codex-code-improvement.md'
 WORKFLOW='.github/workflows/code-quality.yml'
 REVIEW_WORKFLOW='.github/workflows/code-quality-review.yml'
 SHELL_VALIDATION_WORKFLOW='.github/workflows/shell-validation.yml'
+TZDATA_WORKFLOW='.github/workflows/update-tzdata.yml'
 LOCAL_QUALITY_RUNNER='tools/code-quality.sh'
 LOCAL_QUALITY_TEST='tests/code-quality-checks.sh'
 CACHE_WORKFLOW='.github/workflows/cache-adguardhome-static.yml'
@@ -51,7 +52,7 @@ review_checker_is_enforced() {
 	' "${_review_workflow}"
 }
 
-for f in "${CODERABBIT}" "${CODEX_PROMPT}" "${WORKFLOW}" "${REVIEW_WORKFLOW}" "${SHELL_VALIDATION_WORKFLOW}" "${CACHE_WORKFLOW}" "${SCORECARD_WORKFLOW}" "${SONAR_REWRITE}" "${SEMGREP}" "${SONAR}" "${STATIC_DOWNLOADER}"; do
+for f in "${CODERABBIT}" "${CODEX_PROMPT}" "${WORKFLOW}" "${REVIEW_WORKFLOW}" "${SHELL_VALIDATION_WORKFLOW}" "${TZDATA_WORKFLOW}" "${CACHE_WORKFLOW}" "${SCORECARD_WORKFLOW}" "${SONAR_REWRITE}" "${SEMGREP}" "${SONAR}" "${STATIC_DOWNLOADER}"; do
 	[ -f "${f}" ] || fail "expected config file not found: ${f}"
 done
 
@@ -59,7 +60,7 @@ done
 # GitHub Actions both treat tabs as invalid/undefined indentation, and a tab
 # introduced by an editor would not be caught by any shell-focused linter.
 TAB=$(printf '\t')
-for f in "${CODERABBIT}" "${CODEX_PROMPT}" "${WORKFLOW}" "${REVIEW_WORKFLOW}" "${SHELL_VALIDATION_WORKFLOW}" "${SCORECARD_WORKFLOW}"; do
+for f in "${CODERABBIT}" "${CODEX_PROMPT}" "${WORKFLOW}" "${REVIEW_WORKFLOW}" "${SHELL_VALIDATION_WORKFLOW}" "${TZDATA_WORKFLOW}" "${SCORECARD_WORKFLOW}"; do
 	if grep -Fq "${TAB}" "${f}"; then
 		fail "${f}: contains literal tab character(s); YAML/workflow indentation must use spaces"
 	fi
@@ -219,6 +220,14 @@ grep -Fq 'busybox ash tests/installer-preflight-actions.sh' "${SHELL_VALIDATION_
 	fail "${SHELL_VALIDATION_WORKFLOW}: expected the installer preflight action regression to run with BusyBox ash"
 grep -Fq 'busybox ash tests/installer-dns-environment-failure.sh' "${SHELL_VALIDATION_WORKFLOW}" ||
 	fail "${SHELL_VALIDATION_WORKFLOW}: expected the installer NVRAM transaction regression to run with BusyBox ash"
+grep -Fq 'busybox ash tests/update-tzdata-package-info.sh' "${SHELL_VALIDATION_WORKFLOW}" ||
+	fail "${SHELL_VALIDATION_WORKFLOW}: expected the tzdata metadata regression to run with BusyBox ash"
+grep -Fq '      - tests/update-tzdata-package-info.sh' "${TZDATA_WORKFLOW}" ||
+	fail "${TZDATA_WORKFLOW}: tzdata regression changes must trigger the update workflow"
+grep -Fq '      - tools/tzdata-package-info.sh' "${TZDATA_WORKFLOW}" ||
+	fail "${TZDATA_WORKFLOW}: tzdata helper changes must trigger the update workflow"
+grep -Fq '        run: sh tests/update-tzdata-package-info.sh' "${TZDATA_WORKFLOW}" ||
+	fail "${TZDATA_WORKFLOW}: expected the tzdata metadata regression before package publication"
 grep -Fq "run_check 'Installer jq dependency regression' sh tests/installer-jq-helper.sh" "${LOCAL_QUALITY_RUNNER}" ||
 	fail "${LOCAL_QUALITY_RUNNER}: expected the installer jq dependency regression in the local quality matrix"
 grep -Fq 'tests/installer-jq-helper.sh)' "${LOCAL_QUALITY_TEST}" ||

--- a/tests/update-tzdata-package-info.sh
+++ b/tests/update-tzdata-package-info.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+set -eu
+
+REPO_DIR="$(CDPATH= cd -- "$(dirname "${0}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' 0
+
+extract_function="$({
+	awk '
+		/^extract_package_info\(\) \{/ { copying = 1 }
+		copying { print }
+		copying && /^}/ { exit }
+	' "${REPO_DIR}/tools/update-tzdata.sh"
+})"
+if [ -z "${extract_function}" ]; then
+	printf '%s\n' 'extract_package_info function not found' >&2
+	exit 1
+fi
+eval "${extract_function}"
+
+mkdir "${TMP_DIR}/plain" "${TMP_DIR}/dotted"
+printf '%s\n' 'pkgver = 2026c-1' 'arch = aarch64' >"${TMP_DIR}/plain/.PKGINFO"
+cp "${TMP_DIR}/plain/.PKGINFO" "${TMP_DIR}/dotted/.PKGINFO"
+tar -cf "${TMP_DIR}/plain.tar" -C "${TMP_DIR}/plain" .PKGINFO
+tar -cf "${TMP_DIR}/dotted.tar" -C "${TMP_DIR}/dotted" ./.PKGINFO
+
+for archive in "${TMP_DIR}/plain.tar" "${TMP_DIR}/dotted.tar"; do
+	package_info="$(extract_package_info "${archive}")"
+	if ! printf '%s\n' "${package_info}" | grep -q '^pkgver = 2026c-1$'; then
+		printf 'Failed to extract package metadata from %s\n' "${archive}" >&2
+		exit 1
+	fi
+done
+
+printf '%s\n' 'update-tzdata package metadata tests passed'

--- a/tests/update-tzdata-package-info.sh
+++ b/tests/update-tzdata-package-info.sh
@@ -2,13 +2,16 @@
 
 set -eu
 
-if ! REPO_DIR="$(CDPATH= cd -- "$(dirname "${0}")/.." && pwd)"; then
-	printf '%s\n' 'Failed to resolve repository directory' >&2
+fail() {
+	printf 'FAIL: %s\n' "$1" >&2
 	exit 1
+}
+
+if ! REPO_DIR="$(CDPATH= cd -- "$(dirname "${0}")/.." && pwd)"; then
+	fail 'Failed to resolve repository directory'
 fi
 if ! TMP_DIR="$(mktemp -d)"; then
-	printf '%s\n' 'Failed to create tzdata test directory' >&2
-	exit 1
+	fail 'Failed to create tzdata test directory'
 fi
 trap 'rm -rf "${TMP_DIR}"' 0
 
@@ -22,13 +25,25 @@ tar -cf "${TMP_DIR}/dotted.tar" -C "${TMP_DIR}/dotted" ./.PKGINFO
 
 for archive in "${TMP_DIR}/plain.tar" "${TMP_DIR}/dotted.tar"; do
 	if ! package_info="$(extract_package_info "${archive}")"; then
-		printf 'Failed to extract package metadata from %s\n' "${archive}" >&2
-		exit 1
+		fail "Failed to extract package metadata from ${archive}"
 	fi
 	if ! printf '%s\n' "${package_info}" | grep -q '^pkgver = 2026c-1$'; then
-		printf 'Failed to extract package metadata from %s\n' "${archive}" >&2
-		exit 1
+		fail "Failed to extract package metadata from ${archive}"
 	fi
 done
 
-printf '%s\n' 'update-tzdata package metadata tests passed'
+printf '%s\n' 'not package metadata' >"${TMP_DIR}/README"
+printf '%s\n' 'not a tar archive' >"${TMP_DIR}/corrupt.tar"
+tar -cf "${TMP_DIR}/missing-metadata.tar" -C "${TMP_DIR}" README
+
+if extract_package_info "${TMP_DIR}/does-not-exist.tar" >/dev/null 2>&1; then
+	fail 'Missing archive unexpectedly supplied package metadata'
+fi
+if extract_package_info "${TMP_DIR}/corrupt.tar" >/dev/null 2>&1; then
+	fail 'Corrupt archive unexpectedly supplied package metadata'
+fi
+if extract_package_info "${TMP_DIR}/missing-metadata.tar" >/dev/null 2>&1; then
+	fail 'Archive without .PKGINFO unexpectedly supplied package metadata'
+fi
+
+printf '%s\n' 'PASS: update-tzdata package metadata tests passed'

--- a/tests/update-tzdata-package-info.sh
+++ b/tests/update-tzdata-package-info.sh
@@ -2,8 +2,14 @@
 
 set -eu
 
-REPO_DIR="$(CDPATH= cd -- "$(dirname "${0}")/.." && pwd)"
-TMP_DIR="$(mktemp -d)"
+if ! REPO_DIR="$(CDPATH= cd -- "$(dirname "${0}")/.." && pwd)"; then
+	printf '%s\n' 'Failed to resolve repository directory' >&2
+	exit 1
+fi
+if ! TMP_DIR="$(mktemp -d)"; then
+	printf '%s\n' 'Failed to create tzdata test directory' >&2
+	exit 1
+fi
 trap 'rm -rf "${TMP_DIR}"' 0
 
 . "${REPO_DIR}/tools/tzdata-package-info.sh"
@@ -15,7 +21,10 @@ tar -cf "${TMP_DIR}/plain.tar" -C "${TMP_DIR}/plain" .PKGINFO
 tar -cf "${TMP_DIR}/dotted.tar" -C "${TMP_DIR}/dotted" ./.PKGINFO
 
 for archive in "${TMP_DIR}/plain.tar" "${TMP_DIR}/dotted.tar"; do
-	package_info="$(extract_package_info "${archive}")"
+	if ! package_info="$(extract_package_info "${archive}")"; then
+		printf 'Failed to extract package metadata from %s\n' "${archive}" >&2
+		exit 1
+	fi
 	if ! printf '%s\n' "${package_info}" | grep -q '^pkgver = 2026c-1$'; then
 		printf 'Failed to extract package metadata from %s\n' "${archive}" >&2
 		exit 1

--- a/tests/update-tzdata-package-info.sh
+++ b/tests/update-tzdata-package-info.sh
@@ -6,18 +6,7 @@ REPO_DIR="$(CDPATH= cd -- "$(dirname "${0}")/.." && pwd)"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' 0
 
-extract_function="$({
-	awk '
-		/^extract_package_info\(\) \{/ { copying = 1 }
-		copying { print }
-		copying && /^}/ { exit }
-	' "${REPO_DIR}/tools/update-tzdata.sh"
-})"
-if [ -z "${extract_function}" ]; then
-	printf '%s\n' 'extract_package_info function not found' >&2
-	exit 1
-fi
-eval "${extract_function}"
+. "${REPO_DIR}/tools/tzdata-package-info.sh"
 
 mkdir "${TMP_DIR}/plain" "${TMP_DIR}/dotted"
 printf '%s\n' 'pkgver = 2026c-1' 'arch = aarch64' >"${TMP_DIR}/plain/.PKGINFO"

--- a/tools/code-quality.sh
+++ b/tools/code-quality.sh
@@ -260,6 +260,7 @@ run_check 'Installer mandatory numeric input failure regression' sh tests/instal
 run_check 'Installer DNS input failure regression' sh tests/installer-dns-input-failure.sh
 run_check 'Installer WebUI port failure regression' sh tests/installer-web-port-failure.sh
 run_check 'Installer timezone failure regression' sh tests/installer-timezone-failure.sh
+run_check 'tzdata package metadata regression' sh tests/update-tzdata-package-info.sh
 run_check 'Installer branch switch cancellation regression' sh tests/installer-branch-switch-cancel.sh
 run_check 'Installer setting confirmation failure regression' sh tests/installer-setting-confirmation-failure.sh
 run_check 'Installer confirmation failure propagation regression' sh tests/installer-confirmation-failure-propagation.sh

--- a/tools/tzdata-package-info.sh
+++ b/tools/tzdata-package-info.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+extract_package_info() {
+	local package_file package_info_member
+	package_file="$1"
+	package_info_member="$(tar -tf "${package_file}" 2>/dev/null |
+		awk '$0 == ".PKGINFO" || $0 == "./.PKGINFO" { print; exit }')"
+	if [ -z "${package_info_member}" ]; then
+		return 1
+	fi
+
+	tar -xOf "${package_file}" "${package_info_member}" 2>/dev/null
+}

--- a/tools/update-tzdata.sh
+++ b/tools/update-tzdata.sh
@@ -88,6 +88,18 @@ download_verified_pair() {
 	return 1
 }
 
+extract_package_info() {
+	local package_file package_info_member
+	package_file="$1"
+	package_info_member="$(tar -tf "${package_file}" 2>/dev/null |
+		awk '$0 == ".PKGINFO" || $0 == "./.PKGINFO" { print; exit }')"
+	if [ -z "${package_info_member}" ]; then
+		return 1
+	fi
+
+	tar -xOf "${package_file}" "${package_info_member}" 2>/dev/null
+}
+
 discover_package_filename() {
 	local architecture filename mirror_host mirror_url package_listing protocol redirect_protocols
 	architecture="$1"
@@ -142,7 +154,7 @@ download_package() {
 	upstream_file="${stage_dir}/upstream-${architecture}.${filename##*.}"
 	download_verified_pair "${architecture}/core/${filename}" "${upstream_file}" 300
 
-	if ! package_info="$(tar -xOf "${upstream_file}" ./.PKGINFO 2>/dev/null)"; then
+	if ! package_info="$(extract_package_info "${upstream_file}")"; then
 		printf 'Failed to extract .PKGINFO from %s\n' "${upstream_file}" >&2
 		return 1
 	fi

--- a/tools/update-tzdata.sh
+++ b/tools/update-tzdata.sh
@@ -4,6 +4,9 @@
 
 set -eu
 
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "${0}")" && pwd)"
+. "${SCRIPT_DIR}/tzdata-package-info.sh"
+
 OUT_DIR="${1:-.}"
 : "${CURL_CA_BUNDLE:?CURL_CA_BUNDLE is required}"
 : "${MIRROR_HOSTS:?MIRROR_HOSTS is required}"
@@ -86,18 +89,6 @@ download_verified_pair() {
 	rm -f "${output_file}" "${signature_file}"
 	printf 'No mirror supplied a verified copy of %s\n' "${relative_path}" >&2
 	return 1
-}
-
-extract_package_info() {
-	local package_file package_info_member
-	package_file="$1"
-	package_info_member="$(tar -tf "${package_file}" 2>/dev/null |
-		awk '$0 == ".PKGINFO" || $0 == "./.PKGINFO" { print; exit }')"
-	if [ -z "${package_info_member}" ]; then
-		return 1
-	fi
-
-	tar -xOf "${package_file}" "${package_info_member}" 2>/dev/null
 }
 
 discover_package_filename() {


### PR DESCRIPTION
### Motivation
- The `tools/update-tzdata.sh` workflow failed with `Failed to extract .PKGINFO` when upstream package archives used either `.PKGINFO` or `./.PKGINFO` member names, causing the CI step that downloads `tzdata-*-aarch64.pkg.tar.xz`/`tzdata-*-armv7h.pkg.tar.xz` to abort. 
- The change ensures the script handles both archive layouts from Arch Linux ARM mirrors without changing the existing mirror/fallback logic.

### Description
- Added `extract_package_info()` which locates either `.PKGINFO` or `./.PKGINFO` inside an archive and returns its contents. 
- Replaced the direct `tar -xOf ... ./.PKGINFO` call with `extract_package_info` in `download_package()` to accept both metadata member name variants. 
- Kept the mirror discovery and verification flow intact and added a regression test `tests/update-tzdata-package-info.sh` that creates archives with both `.PKGINFO` and `./.PKGINFO` layouts and verifies metadata extraction. 

### Testing
- Ran `sh -n tools/update-tzdata.sh tests/update-tzdata-package-info.sh` which passed. 
- Executed `sh tests/update-tzdata-package-info.sh` which passed and printed `update-tzdata package metadata tests passed`. 
- Ran `sh tools/check-shell-portability.sh tools/update-tzdata.sh tests/update-tzdata-package-info.sh` which passed. 
- Performed `git diff --check` with no issues; note that `shellcheck` was unavailable in the validation environment and live mirror downloads returned HTTP 403 from the environment proxy, so a full end-to-end mirror fetch was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d2b024470832987092a01a454258d)