### PR TITLE
fix: normalize tzdata POSIX payload when upstream omits posix/

### DIFF
--- a/.github/workflows/code-quality-review.yml
+++ b/.github/workflows/code-quality-review.yml
@@ -97,12 +97,19 @@ jobs:
           printf '%s\n' "${JAVA_HOME_21_X64}/bin" >> "${GITHUB_PATH}"
           "${JAVA_HOME_21_X64}/bin/java" -version
 
-      - name: Run tzdata normalizer regression before analysis
+      - name: Install Python coverage tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-coverage
+
+      - name: Run tzdata normalizer regression and collect coverage
         env:
           PYTHON3: /usr/bin/python3
         run: |
           "${PYTHON3}" --version
           sh tests/update-tzdata-package-info.sh
+          "${PYTHON3}" -m coverage run --branch --include='tools/normalize-tzdata-package.py' tests/normalize-tzdata-package.py
+          "${PYTHON3}" -m coverage xml -o coverage.xml
 
       - name: SonarQube Cloud scan and quality gate
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1

--- a/.github/workflows/code-quality-review.yml
+++ b/.github/workflows/code-quality-review.yml
@@ -97,6 +97,13 @@ jobs:
           printf '%s\n' "${JAVA_HOME_21_X64}/bin" >> "${GITHUB_PATH}"
           "${JAVA_HOME_21_X64}/bin/java" -version
 
+      - name: Run tzdata normalizer regression before analysis
+        env:
+          PYTHON3: /usr/bin/python3
+        run: |
+          "${PYTHON3}" --version
+          sh tests/update-tzdata-package-info.sh
+
       - name: SonarQube Cloud scan and quality gate
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         with:

--- a/.github/workflows/shell-validation.yml
+++ b/.github/workflows/shell-validation.yml
@@ -60,6 +60,8 @@ jobs:
         run: /usr/bin/timeout --kill-after=10 180 busybox ash tests/static-checksum-output-validation.sh
 
       - name: Run tzdata package metadata regression
+        env:
+          PYTHON3: /usr/bin/python3
         run: /usr/bin/timeout --kill-after=10 180 busybox ash tests/update-tzdata-package-info.sh
 
       - name: Run installer jq dependency regression

--- a/.github/workflows/update-tzdata.yml
+++ b/.github/workflows/update-tzdata.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - .github/workflows/update-tzdata.yml
       - tests/update-tzdata-package-info.sh
+      - tests/normalize-tzdata-package.py
       - tools/tzdata-package-info.sh
       - tools/normalize-tzdata-package.py
       - tools/update-tzdata.sh

--- a/.github/workflows/update-tzdata.yml
+++ b/.github/workflows/update-tzdata.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/update-tzdata.yml
       - tests/update-tzdata-package-info.sh
       - tools/tzdata-package-info.sh
+      - tools/normalize-tzdata-package.py
       - tools/update-tzdata.sh
   schedule:
     - cron: '23 4 * * 1'

--- a/.github/workflows/update-tzdata.yml
+++ b/.github/workflows/update-tzdata.yml
@@ -75,6 +75,8 @@ jobs:
           persist-credentials: true
 
       - name: Run tzdata package metadata regression
+        env:
+          PYTHON3: /usr/bin/python3
         run: sh tests/update-tzdata-package-info.sh
 
       - name: Download current packages

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,6 +4,7 @@ sonar.sources=.
 sonar.tests=tests
 sonar.exclusions=tests/**,**/node_modules/**,**/.*,**/*.tar.gz,**/*.pkg.tar.bz2
 sonar.test.inclusions=tests/**
+sonar.python.coverage.reportPaths=coverage.xml
 sonar.shell.file.suffixes=.sh
 sonar.lang.patterns.shell=**/*.sh,installer,S99AdGuardHome,rc.func.AdGuardHome
 

--- a/tests/code-quality-checks.sh
+++ b/tests/code-quality-checks.sh
@@ -350,6 +350,9 @@ for t in tests/*.sh; do
 		fail "${t} is not referenced by any run_check in ${SCRIPT_PATH}; new test files must be wired in or they get zero CI coverage"
 done
 
+grep -Fq "run_check 'tzdata normalizer Python regression' \"\${PYTHON3:-python3}\" tests/normalize-tzdata-package.py" "${SCRIPT_PATH}" ||
+	fail 'tzdata normalizer Python regression is not registered in tools/code-quality.sh'
+
 grep -Fq "run_long_check 'AdGuardHome service lifecycle integration regression' \"\${SERVICE_LIFECYCLE_MAX_RUNTIME_SECONDS}\" run_privileged_regression_check tests/service-lifecycle-integration.sh 'service lifecycle integration regression'" "${SCRIPT_PATH}" ||
 	fail 'service lifecycle integration regression does not use its dedicated timeout and privileged test helper'
 

--- a/tests/coderabbit-and-workflow-config-checks.sh
+++ b/tests/coderabbit-and-workflow-config-checks.sh
@@ -226,18 +226,26 @@ grep -Fq '          PYTHON3: /usr/bin/python3' "${SHELL_VALIDATION_WORKFLOW}" ||
 	fail "${SHELL_VALIDATION_WORKFLOW}: expected an explicit host Python for the tzdata regression"
 grep -Fq '      - tests/update-tzdata-package-info.sh' "${TZDATA_WORKFLOW}" ||
 	fail "${TZDATA_WORKFLOW}: tzdata regression changes must trigger the update workflow"
+grep -Fq '      - tests/normalize-tzdata-package.py' "${TZDATA_WORKFLOW}" ||
+	fail "${TZDATA_WORKFLOW}: tzdata Python regression changes must trigger the update workflow"
 grep -Fq '      - tools/tzdata-package-info.sh' "${TZDATA_WORKFLOW}" ||
 	fail "${TZDATA_WORKFLOW}: tzdata helper changes must trigger the update workflow"
 grep -Fq '      - tools/normalize-tzdata-package.py' "${TZDATA_WORKFLOW}" ||
 	fail "${TZDATA_WORKFLOW}: tzdata normalizer changes must trigger the update workflow"
 grep -Fq '        run: sh tests/update-tzdata-package-info.sh' "${TZDATA_WORKFLOW}" ||
 	fail "${TZDATA_WORKFLOW}: expected the tzdata metadata regression before package publication"
-grep -Fq '      - name: Run tzdata normalizer regression before analysis' "${REVIEW_WORKFLOW}" ||
-	fail "${REVIEW_WORKFLOW}: expected the tzdata security regression before Sonar analysis"
+grep -Fq '      - name: Run tzdata normalizer regression and collect coverage' "${REVIEW_WORKFLOW}" ||
+	fail "${REVIEW_WORKFLOW}: expected the tzdata security regression and coverage before Sonar analysis"
 grep -Fq '          sh tests/update-tzdata-package-info.sh' "${REVIEW_WORKFLOW}" ||
 	fail "${REVIEW_WORKFLOW}: expected the tzdata security regression command before Sonar analysis"
+grep -Fq "          \"\${PYTHON3}\" -m coverage run --branch --include='tools/normalize-tzdata-package.py' tests/normalize-tzdata-package.py" "${REVIEW_WORKFLOW}" ||
+	fail "${REVIEW_WORKFLOW}: expected Python coverage collection for the tzdata normalizer"
+grep -Fqx 'sonar.python.coverage.reportPaths=coverage.xml' "${SONAR}" ||
+	fail "${SONAR}: expected Sonar to import Python coverage"
 grep -Fq "run_check 'tzdata package metadata regression' sh tests/update-tzdata-package-info.sh" "${LOCAL_QUALITY_RUNNER}" ||
 	fail "${LOCAL_QUALITY_RUNNER}: expected the tzdata metadata regression in the local and CI quality matrix"
+grep -Fq "run_check 'tzdata normalizer Python regression' \"\${PYTHON3:-python3}\" tests/normalize-tzdata-package.py" "${LOCAL_QUALITY_RUNNER}" ||
+	fail "${LOCAL_QUALITY_RUNNER}: expected the tzdata Python regression in the local and CI quality matrix"
 grep -Fq "run_check 'Installer jq dependency regression' sh tests/installer-jq-helper.sh" "${LOCAL_QUALITY_RUNNER}" ||
 	fail "${LOCAL_QUALITY_RUNNER}: expected the installer jq dependency regression in the local quality matrix"
 grep -Fq 'tests/installer-jq-helper.sh)' "${LOCAL_QUALITY_TEST}" ||

--- a/tests/coderabbit-and-workflow-config-checks.sh
+++ b/tests/coderabbit-and-workflow-config-checks.sh
@@ -226,6 +226,8 @@ grep -Fq '      - tests/update-tzdata-package-info.sh' "${TZDATA_WORKFLOW}" ||
 	fail "${TZDATA_WORKFLOW}: tzdata regression changes must trigger the update workflow"
 grep -Fq '      - tools/tzdata-package-info.sh' "${TZDATA_WORKFLOW}" ||
 	fail "${TZDATA_WORKFLOW}: tzdata helper changes must trigger the update workflow"
+grep -Fq '      - tools/normalize-tzdata-package.py' "${TZDATA_WORKFLOW}" ||
+	fail "${TZDATA_WORKFLOW}: tzdata normalizer changes must trigger the update workflow"
 grep -Fq '        run: sh tests/update-tzdata-package-info.sh' "${TZDATA_WORKFLOW}" ||
 	fail "${TZDATA_WORKFLOW}: expected the tzdata metadata regression before package publication"
 grep -Fq "run_check 'tzdata package metadata regression' sh tests/update-tzdata-package-info.sh" "${LOCAL_QUALITY_RUNNER}" ||

--- a/tests/coderabbit-and-workflow-config-checks.sh
+++ b/tests/coderabbit-and-workflow-config-checks.sh
@@ -222,6 +222,8 @@ grep -Fq 'busybox ash tests/installer-dns-environment-failure.sh' "${SHELL_VALID
 	fail "${SHELL_VALIDATION_WORKFLOW}: expected the installer NVRAM transaction regression to run with BusyBox ash"
 grep -Fq 'busybox ash tests/update-tzdata-package-info.sh' "${SHELL_VALIDATION_WORKFLOW}" ||
 	fail "${SHELL_VALIDATION_WORKFLOW}: expected the tzdata metadata regression to run with BusyBox ash"
+grep -Fq '          PYTHON3: /usr/bin/python3' "${SHELL_VALIDATION_WORKFLOW}" ||
+	fail "${SHELL_VALIDATION_WORKFLOW}: expected an explicit host Python for the tzdata regression"
 grep -Fq '      - tests/update-tzdata-package-info.sh' "${TZDATA_WORKFLOW}" ||
 	fail "${TZDATA_WORKFLOW}: tzdata regression changes must trigger the update workflow"
 grep -Fq '      - tools/tzdata-package-info.sh' "${TZDATA_WORKFLOW}" ||
@@ -230,6 +232,10 @@ grep -Fq '      - tools/normalize-tzdata-package.py' "${TZDATA_WORKFLOW}" ||
 	fail "${TZDATA_WORKFLOW}: tzdata normalizer changes must trigger the update workflow"
 grep -Fq '        run: sh tests/update-tzdata-package-info.sh' "${TZDATA_WORKFLOW}" ||
 	fail "${TZDATA_WORKFLOW}: expected the tzdata metadata regression before package publication"
+grep -Fq '      - name: Run tzdata normalizer regression before analysis' "${REVIEW_WORKFLOW}" ||
+	fail "${REVIEW_WORKFLOW}: expected the tzdata security regression before Sonar analysis"
+grep -Fq '          sh tests/update-tzdata-package-info.sh' "${REVIEW_WORKFLOW}" ||
+	fail "${REVIEW_WORKFLOW}: expected the tzdata security regression command before Sonar analysis"
 grep -Fq "run_check 'tzdata package metadata regression' sh tests/update-tzdata-package-info.sh" "${LOCAL_QUALITY_RUNNER}" ||
 	fail "${LOCAL_QUALITY_RUNNER}: expected the tzdata metadata regression in the local and CI quality matrix"
 grep -Fq "run_check 'Installer jq dependency regression' sh tests/installer-jq-helper.sh" "${LOCAL_QUALITY_RUNNER}" ||

--- a/tests/normalize-tzdata-package.py
+++ b/tests/normalize-tzdata-package.py
@@ -51,6 +51,7 @@ class NormalizeTzdataPackageTests(unittest.TestCase):
 			package.addfile(alias)
 			if include_posix:
 				add_file(package, "./usr/share/zoneinfo/posix/Etc/UTC", b"TZif existing\n")
+				add_file(package, "./usr/share/zoneinfo/posix/UTC", b"TZif existing alias\n")
 			if partial_posix:
 				add_file(package, "./usr/share/zoneinfo/posix/.placeholder", b"not timezone data\n")
 			if posix_alias:
@@ -85,15 +86,33 @@ class NormalizeTzdataPackageTests(unittest.TestCase):
 
 		self.assertEqual(archive.read_bytes(), before)
 
-	def test_existing_posix_alias_is_unchanged(self):
-		"""Accept a POSIX alias that resolves to usable timezone data."""
+	def test_existing_posix_alias_is_materialized(self):
+		"""Rewrite a POSIX alias as a file safe for subtree extraction."""
 		archive = self.archive()
 		self.create_package(archive, posix_alias=True)
-		before = archive.read_bytes()
 
 		NORMALIZER.main(os.fspath(archive))
 
-		self.assertEqual(archive.read_bytes(), before)
+		with tarfile.open(archive, "r:bz2") as package:
+			members = {NORMALIZER.normalized_member_name(member.name): member for member in package.getmembers()}
+			alias = members["usr/share/zoneinfo/posix/UTC"]
+			self.assertTrue(alias.isfile())
+			with package.extractfile(alias) as stream:
+				self.assertEqual(stream.read(), b"TZif standard\n")
+
+	def test_incomplete_posix_payload_is_rebuilt(self):
+		"""Add source zones missing from an otherwise usable POSIX tree."""
+		archive = self.archive()
+		with tarfile.open(archive, "w:bz2") as package:
+			add_file(package, "./usr/share/zoneinfo/Etc/UTC", b"TZif standard\n")
+			add_file(package, "./usr/share/zoneinfo/Asia/Tokyo", b"TZif Tokyo\n")
+			add_file(package, "./usr/share/zoneinfo/posix/Etc/UTC", b"TZif existing\n")
+
+		NORMALIZER.main(os.fspath(archive))
+
+		with tarfile.open(archive, "r:bz2") as package:
+			members = {NORMALIZER.normalized_member_name(member.name): member for member in package.getmembers()}
+			self.assertIn("usr/share/zoneinfo/posix/Asia/Tokyo", members)
 
 	def test_partial_posix_payload_is_replaced(self):
 		"""Replace a placeholder-only POSIX tree with usable timezone data."""

--- a/tests/normalize-tzdata-package.py
+++ b/tests/normalize-tzdata-package.py
@@ -1,0 +1,139 @@
+#!/usr/bin/python3
+"""Regression tests for the host-side tzdata package normalizer."""
+
+import importlib.util
+import io
+import os
+import pathlib
+import tarfile
+import tempfile
+import unittest
+
+
+REPO_DIR = pathlib.Path(__file__).resolve().parent.parent
+NORMALIZER_PATH = REPO_DIR / "tools" / "normalize-tzdata-package.py"
+SPEC = importlib.util.spec_from_file_location("normalize_tzdata_package", NORMALIZER_PATH)
+NORMALIZER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(NORMALIZER)
+
+
+def add_file(package, name, payload):
+	"""Add one regular in-memory file to a tar package."""
+	member = tarfile.TarInfo(name)
+	member.size = len(payload)
+	package.addfile(member, io.BytesIO(payload))
+
+
+class NormalizeTzdataPackageTests(unittest.TestCase):
+	"""Exercise normalization and each security-sensitive rejection path."""
+
+	def setUp(self):
+		"""Create an isolated archive workspace."""
+		self.temporary = tempfile.TemporaryDirectory()
+		self.directory = pathlib.Path(self.temporary.name)
+
+	def tearDown(self):
+		"""Remove the isolated archive workspace."""
+		self.temporary.cleanup()
+
+	def archive(self, name="tzdata.tar.bz2"):
+		"""Return a package path inside the isolated workspace."""
+		return self.directory / name
+
+	def create_package(self, archive, include_posix=False):
+		"""Create a minimal tzdata package containing a file and aliases."""
+		with tarfile.open(archive, "w:bz2") as package:
+			add_file(package, "./usr/share/zoneinfo/Etc/UTC", b"TZif standard\n")
+			add_file(package, "./usr/share/zoneinfo/right/Etc/UTC", b"TZif right\n")
+			alias = tarfile.TarInfo("./usr/share/zoneinfo/UTC")
+			alias.type = tarfile.SYMTYPE
+			alias.linkname = "Etc/UTC"
+			package.addfile(alias)
+			if include_posix:
+				add_file(package, "./usr/share/zoneinfo/posix/Etc/UTC", b"TZif existing\n")
+
+	def test_normalizes_payload_and_materializes_alias(self):
+		"""Synthesize POSIX files without copying the leap-second tree."""
+		archive = self.archive()
+		self.create_package(archive)
+
+		NORMALIZER.main(os.fspath(archive))
+
+		with tarfile.open(archive, "r:bz2") as package:
+			members = {NORMALIZER.normalized_member_name(member.name): member for member in package.getmembers()}
+			self.assertIn("usr/share/zoneinfo/posix/Etc/UTC", members)
+			self.assertNotIn("usr/share/zoneinfo/posix/right/Etc/UTC", members)
+			alias = members["usr/share/zoneinfo/posix/UTC"]
+			self.assertTrue(alias.isfile())
+			with package.extractfile(alias) as stream:
+				self.assertEqual(stream.read(), b"TZif standard\n")
+
+	def test_existing_posix_payload_is_unchanged(self):
+		"""Return without rewriting a package that already has POSIX data."""
+		archive = self.archive()
+		self.create_package(archive, include_posix=True)
+		before = archive.read_bytes()
+
+		NORMALIZER.main(os.fspath(archive))
+
+		self.assertEqual(archive.read_bytes(), before)
+
+	def test_rejects_unsafe_member_and_link_paths(self):
+		"""Reject traversal in both member names and symbolic-link targets."""
+		for name, member_name, link_name in (
+			("member.tar.bz2", "../escape", None),
+			("link.tar.bz2", "usr/share/zoneinfo/UTC", "../../../../escape"),
+		):
+			with self.subTest(name=name):
+				archive = self.archive(name)
+				with tarfile.open(archive, "w:bz2") as package:
+					member = tarfile.TarInfo(member_name)
+					if link_name is not None:
+						member.type = tarfile.SYMTYPE
+						member.linkname = link_name
+					package.addfile(member)
+				with self.assertRaises(SystemExit):
+					NORMALIZER.main(os.fspath(archive))
+
+	def test_rejects_invalid_archive_paths(self):
+		"""Reject missing, incorrectly suffixed, and symbolic-link inputs."""
+		with self.assertRaises(SystemExit):
+			NORMALIZER.main(os.fspath(self.archive("missing.tar.bz2")))
+		invalid_suffix = self.archive("tzdata.tbz")
+		invalid_suffix.touch()
+		with self.assertRaises(SystemExit):
+			NORMALIZER.main(os.fspath(invalid_suffix))
+		target = self.archive()
+		self.create_package(target)
+		linked = self.archive("linked.tar.bz2")
+		linked.symlink_to(target.name)
+		with self.assertRaises(SystemExit):
+			NORMALIZER.main(os.fspath(linked))
+
+	def test_rejects_unusable_and_broken_alias_payloads(self):
+		"""Reject packages without TZif data and invalid selected alias chains."""
+		empty = self.archive("empty.tar.bz2")
+		with tarfile.open(empty, "w:bz2") as package:
+			add_file(package, "./README", b"not timezone data\n")
+		with self.assertRaises(SystemExit):
+			NORMALIZER.main(os.fspath(empty))
+
+		first = tarfile.TarInfo("usr/share/zoneinfo/First")
+		first.type = tarfile.SYMTYPE
+		first.linkname = "Second"
+		second = tarfile.TarInfo("usr/share/zoneinfo/Second")
+		second.type = tarfile.SYMTYPE
+		second.linkname = "First"
+		members = {
+			NORMALIZER.normalized_member_name(first.name): first,
+			NORMALIZER.normalized_member_name(second.name): second,
+		}
+		with self.assertRaises(SystemExit):
+			NORMALIZER.linked_file(first, members)
+		del members[NORMALIZER.normalized_member_name(second.name)]
+		with self.assertRaises(SystemExit):
+			NORMALIZER.linked_file(first, members)
+
+
+if __name__ == "__main__":
+	unittest.main(argv=[__file__])

--- a/tests/normalize-tzdata-package.py
+++ b/tests/normalize-tzdata-package.py
@@ -40,7 +40,7 @@ class NormalizeTzdataPackageTests(unittest.TestCase):
 		"""Return a package path inside the isolated workspace."""
 		return self.directory / name
 
-	def create_package(self, archive, include_posix=False):
+	def create_package(self, archive, include_posix=False, partial_posix=False, posix_alias=False):
 		"""Create a minimal tzdata package containing a file and aliases."""
 		with tarfile.open(archive, "w:bz2") as package:
 			add_file(package, "./usr/share/zoneinfo/Etc/UTC", b"TZif standard\n")
@@ -51,6 +51,13 @@ class NormalizeTzdataPackageTests(unittest.TestCase):
 			package.addfile(alias)
 			if include_posix:
 				add_file(package, "./usr/share/zoneinfo/posix/Etc/UTC", b"TZif existing\n")
+			if partial_posix:
+				add_file(package, "./usr/share/zoneinfo/posix/.placeholder", b"not timezone data\n")
+			if posix_alias:
+				alias = tarfile.TarInfo("./usr/share/zoneinfo/posix/UTC")
+				alias.type = tarfile.SYMTYPE
+				alias.linkname = "../Etc/UTC"
+				package.addfile(alias)
 
 	def test_normalizes_payload_and_materializes_alias(self):
 		"""Synthesize POSIX files without copying the leap-second tree."""
@@ -77,6 +84,28 @@ class NormalizeTzdataPackageTests(unittest.TestCase):
 		NORMALIZER.main(os.fspath(archive))
 
 		self.assertEqual(archive.read_bytes(), before)
+
+	def test_existing_posix_alias_is_unchanged(self):
+		"""Accept a POSIX alias that resolves to usable timezone data."""
+		archive = self.archive()
+		self.create_package(archive, posix_alias=True)
+		before = archive.read_bytes()
+
+		NORMALIZER.main(os.fspath(archive))
+
+		self.assertEqual(archive.read_bytes(), before)
+
+	def test_partial_posix_payload_is_replaced(self):
+		"""Replace a placeholder-only POSIX tree with usable timezone data."""
+		archive = self.archive()
+		self.create_package(archive, partial_posix=True)
+
+		NORMALIZER.main(os.fspath(archive))
+
+		with tarfile.open(archive, "r:bz2") as package:
+			members = {NORMALIZER.normalized_member_name(member.name): member for member in package.getmembers()}
+			self.assertIn("usr/share/zoneinfo/posix/Etc/UTC", members)
+			self.assertNotIn("usr/share/zoneinfo/posix/.placeholder", members)
 
 	def test_rejects_unsafe_member_and_link_paths(self):
 		"""Reject traversal in both member names and symbolic-link targets."""

--- a/tests/normalize-tzdata-package.py
+++ b/tests/normalize-tzdata-package.py
@@ -92,31 +92,36 @@ class NormalizeTzdataPackageTests(unittest.TestCase):
 						member.type = tarfile.SYMTYPE
 						member.linkname = link_name
 					package.addfile(member)
+				archive_path = os.fspath(archive)
 				with self.assertRaises(SystemExit):
-					NORMALIZER.main(os.fspath(archive))
+					NORMALIZER.main(archive_path)
 
 	def test_rejects_invalid_archive_paths(self):
 		"""Reject missing, incorrectly suffixed, and symbolic-link inputs."""
+		missing_path = os.fspath(self.archive("missing.tar.bz2"))
 		with self.assertRaises(SystemExit):
-			NORMALIZER.main(os.fspath(self.archive("missing.tar.bz2")))
+			NORMALIZER.main(missing_path)
 		invalid_suffix = self.archive("tzdata.tbz")
 		invalid_suffix.touch()
+		invalid_suffix_path = os.fspath(invalid_suffix)
 		with self.assertRaises(SystemExit):
-			NORMALIZER.main(os.fspath(invalid_suffix))
+			NORMALIZER.main(invalid_suffix_path)
 		target = self.archive()
 		self.create_package(target)
 		linked = self.archive("linked.tar.bz2")
 		linked.symlink_to(target.name)
+		linked_path = os.fspath(linked)
 		with self.assertRaises(SystemExit):
-			NORMALIZER.main(os.fspath(linked))
+			NORMALIZER.main(linked_path)
 
 	def test_rejects_unusable_and_broken_alias_payloads(self):
 		"""Reject packages without TZif data and invalid selected alias chains."""
 		empty = self.archive("empty.tar.bz2")
 		with tarfile.open(empty, "w:bz2") as package:
 			add_file(package, "./README", b"not timezone data\n")
+		empty_path = os.fspath(empty)
 		with self.assertRaises(SystemExit):
-			NORMALIZER.main(os.fspath(empty))
+			NORMALIZER.main(empty_path)
 
 		first = tarfile.TarInfo("usr/share/zoneinfo/First")
 		first.type = tarfile.SYMTYPE

--- a/tests/update-tzdata-package-info.sh
+++ b/tests/update-tzdata-package-info.sh
@@ -66,8 +66,10 @@ if ! tar -xOjf "${TMP_DIR}/tzdata-without-posix.tar.bz2" ./.PKGINFO |
 fi
 
 mkdir -p "${TMP_DIR}/tzdata-with-posix-alias/usr/share/zoneinfo/Etc" \
+	"${TMP_DIR}/tzdata-with-posix-alias/usr/share/zoneinfo/Asia" \
 	"${TMP_DIR}/tzdata-with-posix-alias/usr/share/zoneinfo/posix"
 printf 'TZif existing timezone\n' >"${TMP_DIR}/tzdata-with-posix-alias/usr/share/zoneinfo/Etc/UTC"
+printf 'TZif missing POSIX timezone\n' >"${TMP_DIR}/tzdata-with-posix-alias/usr/share/zoneinfo/Asia/Tokyo"
 ln -s ../Etc/UTC "${TMP_DIR}/tzdata-with-posix-alias/usr/share/zoneinfo/posix/UTC"
 tar -cjf "${TMP_DIR}/tzdata-with-posix-alias.tar.bz2" -C "${TMP_DIR}/tzdata-with-posix-alias" .
 "${python3_cmd}" "${normalizer}" "${TMP_DIR}/tzdata-with-posix-alias.tar.bz2"
@@ -79,6 +81,10 @@ if [ -L "${TMP_DIR}/normalized-existing/usr/share/zoneinfo/posix/UTC" ]; then
 fi
 if [ "$(cat "${TMP_DIR}/normalized-existing/usr/share/zoneinfo/posix/UTC")" != 'TZif existing timezone' ]; then
 	fail 'Failed to preserve an existing POSIX timezone alias'
+fi
+if [ "$(cat "${TMP_DIR}/normalized-existing/usr/share/zoneinfo/posix/Asia/Tokyo")" != \
+	'TZif missing POSIX timezone' ]; then
+	fail 'Failed to rebuild a partially populated POSIX timezone tree'
 fi
 
 cp "${TMP_DIR}/tzdata-without-posix.tar.bz2" "${TMP_DIR}/invalid-suffix.tbz"

--- a/tests/update-tzdata-package-info.sh
+++ b/tests/update-tzdata-package-info.sh
@@ -32,8 +32,9 @@ for archive in "${TMP_DIR}/plain.tar" "${TMP_DIR}/dotted.tar"; do
 	fi
 done
 
-mkdir -p "${TMP_DIR}/tzdata/usr/share/zoneinfo/Etc"
+mkdir -p "${TMP_DIR}/tzdata/usr/share/zoneinfo/Etc" "${TMP_DIR}/tzdata/usr/share/zoneinfo/right/Etc"
 printf 'TZif test timezone\n' >"${TMP_DIR}/tzdata/usr/share/zoneinfo/Etc/UTC"
+printf 'TZif leap-second timezone\n' >"${TMP_DIR}/tzdata/usr/share/zoneinfo/right/Etc/UTC"
 ln -s Etc/UTC "${TMP_DIR}/tzdata/usr/share/zoneinfo/UTC"
 printf '%s\n' 'package metadata' >"${TMP_DIR}/tzdata/.PKGINFO"
 tar -cjf "${TMP_DIR}/tzdata-without-posix.tar.bz2" -C "${TMP_DIR}/tzdata" .
@@ -41,6 +42,10 @@ tar -cjf "${TMP_DIR}/tzdata-without-posix.tar.bz2" -C "${TMP_DIR}/tzdata" .
 if ! tar -xOf "${TMP_DIR}/tzdata-without-posix.tar.bz2" ./usr/share/zoneinfo/posix/Etc/UTC |
 	grep -q '^TZif test timezone$'; then
 	fail 'Failed to add the installer-compatible POSIX timezone payload'
+fi
+if tar -tf "${TMP_DIR}/tzdata-without-posix.tar.bz2" |
+	grep -q '^\./usr/share/zoneinfo/posix/right/'; then
+	fail 'Added leap-second-aware timezone data to the POSIX payload'
 fi
 mkdir "${TMP_DIR}/normalized"
 tar -xjf "${TMP_DIR}/tzdata-without-posix.tar.bz2" -C "${TMP_DIR}/normalized" ./usr/share/zoneinfo/posix

--- a/tests/update-tzdata-package-info.sh
+++ b/tests/update-tzdata-package-info.sh
@@ -32,6 +32,26 @@ for archive in "${TMP_DIR}/plain.tar" "${TMP_DIR}/dotted.tar"; do
 	fi
 done
 
+mkdir -p "${TMP_DIR}/tzdata/usr/share/zoneinfo/Etc"
+printf 'TZif test timezone\n' >"${TMP_DIR}/tzdata/usr/share/zoneinfo/Etc/UTC"
+ln -s Etc/UTC "${TMP_DIR}/tzdata/usr/share/zoneinfo/UTC"
+printf '%s\n' 'package metadata' >"${TMP_DIR}/tzdata/.PKGINFO"
+tar -cjf "${TMP_DIR}/tzdata-without-posix.tar.bz2" -C "${TMP_DIR}/tzdata" .
+/usr/bin/python3 "${REPO_DIR}/tools/normalize-tzdata-package.py" "${TMP_DIR}/tzdata-without-posix.tar.bz2"
+if ! tar -xOf "${TMP_DIR}/tzdata-without-posix.tar.bz2" ./usr/share/zoneinfo/posix/Etc/UTC |
+	grep -q '^TZif test timezone$'; then
+	fail 'Failed to add the installer-compatible POSIX timezone payload'
+fi
+mkdir "${TMP_DIR}/normalized"
+tar -xjf "${TMP_DIR}/tzdata-without-posix.tar.bz2" -C "${TMP_DIR}/normalized" ./usr/share/zoneinfo/posix
+if [ "$(cat "${TMP_DIR}/normalized/usr/share/zoneinfo/posix/UTC")" != 'TZif test timezone' ]; then
+	fail 'Failed to preserve timezone aliases in the POSIX payload'
+fi
+if ! tar -xOf "${TMP_DIR}/tzdata-without-posix.tar.bz2" ./.PKGINFO |
+	grep -q '^package metadata$'; then
+	fail 'Timezone normalization did not preserve package metadata'
+fi
+
 printf '%s\n' 'not package metadata' >"${TMP_DIR}/README"
 printf '%s\n' 'not a tar archive' >"${TMP_DIR}/corrupt.tar"
 tar -cf "${TMP_DIR}/missing-metadata.tar" -C "${TMP_DIR}" README

--- a/tests/update-tzdata-package-info.sh
+++ b/tests/update-tzdata-package-info.sh
@@ -38,7 +38,11 @@ printf 'TZif leap-second timezone\n' >"${TMP_DIR}/tzdata/usr/share/zoneinfo/righ
 ln -s Etc/UTC "${TMP_DIR}/tzdata/usr/share/zoneinfo/UTC"
 printf '%s\n' 'package metadata' >"${TMP_DIR}/tzdata/.PKGINFO"
 tar -cjf "${TMP_DIR}/tzdata-without-posix.tar.bz2" -C "${TMP_DIR}/tzdata" .
-/usr/bin/python3 "${REPO_DIR}/tools/normalize-tzdata-package.py" "${TMP_DIR}/tzdata-without-posix.tar.bz2"
+python3_cmd="${PYTHON3:-python3}"
+if ! command -v "${python3_cmd}" >/dev/null 2>&1; then
+	fail "Selected Python 3 interpreter is unavailable: ${python3_cmd}"
+fi
+"${python3_cmd}" "${REPO_DIR}/tools/normalize-tzdata-package.py" "${TMP_DIR}/tzdata-without-posix.tar.bz2"
 if ! tar -xOf "${TMP_DIR}/tzdata-without-posix.tar.bz2" ./usr/share/zoneinfo/posix/Etc/UTC |
 	grep -q '^TZif test timezone$'; then
 	fail 'Failed to add the installer-compatible POSIX timezone payload'

--- a/tests/update-tzdata-package-info.sh
+++ b/tests/update-tzdata-package-info.sh
@@ -49,6 +49,9 @@ if tar -tf "${TMP_DIR}/tzdata-without-posix.tar.bz2" |
 fi
 mkdir "${TMP_DIR}/normalized"
 tar -xjf "${TMP_DIR}/tzdata-without-posix.tar.bz2" -C "${TMP_DIR}/normalized" ./usr/share/zoneinfo/posix
+if [ -L "${TMP_DIR}/normalized/usr/share/zoneinfo/posix/UTC" ]; then
+	fail 'Timezone aliases were not materialized in the POSIX payload'
+fi
 if [ "$(cat "${TMP_DIR}/normalized/usr/share/zoneinfo/posix/UTC")" != 'TZif test timezone' ]; then
 	fail 'Failed to preserve timezone aliases in the POSIX payload'
 fi

--- a/tests/update-tzdata-package-info.sh
+++ b/tests/update-tzdata-package-info.sh
@@ -44,11 +44,11 @@ if ! command -v "${python3_cmd}" >/dev/null 2>&1; then
 fi
 normalizer="${REPO_DIR}/tools/normalize-tzdata-package.py"
 "${python3_cmd}" "${normalizer}" "${TMP_DIR}/tzdata-without-posix.tar.bz2"
-if ! tar -xOf "${TMP_DIR}/tzdata-without-posix.tar.bz2" ./usr/share/zoneinfo/posix/Etc/UTC |
+if ! tar -xOjf "${TMP_DIR}/tzdata-without-posix.tar.bz2" ./usr/share/zoneinfo/posix/Etc/UTC |
 	grep -q '^TZif test timezone$'; then
 	fail 'Failed to add the installer-compatible POSIX timezone payload'
 fi
-if tar -tf "${TMP_DIR}/tzdata-without-posix.tar.bz2" |
+if tar -tjf "${TMP_DIR}/tzdata-without-posix.tar.bz2" |
 	grep -q '^\./usr/share/zoneinfo/posix/right/'; then
 	fail 'Added leap-second-aware timezone data to the POSIX payload'
 fi
@@ -60,7 +60,7 @@ fi
 if [ "$(cat "${TMP_DIR}/normalized/usr/share/zoneinfo/posix/UTC")" != 'TZif test timezone' ]; then
 	fail 'Failed to preserve timezone aliases in the POSIX payload'
 fi
-if ! tar -xOf "${TMP_DIR}/tzdata-without-posix.tar.bz2" ./.PKGINFO |
+if ! tar -xOjf "${TMP_DIR}/tzdata-without-posix.tar.bz2" ./.PKGINFO |
 	grep -q '^package metadata$'; then
 	fail 'Timezone normalization did not preserve package metadata'
 fi

--- a/tests/update-tzdata-package-info.sh
+++ b/tests/update-tzdata-package-info.sh
@@ -65,6 +65,22 @@ if ! tar -xOjf "${TMP_DIR}/tzdata-without-posix.tar.bz2" ./.PKGINFO |
 	fail 'Timezone normalization did not preserve package metadata'
 fi
 
+mkdir -p "${TMP_DIR}/tzdata-with-posix-alias/usr/share/zoneinfo/Etc" \
+	"${TMP_DIR}/tzdata-with-posix-alias/usr/share/zoneinfo/posix"
+printf 'TZif existing timezone\n' >"${TMP_DIR}/tzdata-with-posix-alias/usr/share/zoneinfo/Etc/UTC"
+ln -s ../Etc/UTC "${TMP_DIR}/tzdata-with-posix-alias/usr/share/zoneinfo/posix/UTC"
+tar -cjf "${TMP_DIR}/tzdata-with-posix-alias.tar.bz2" -C "${TMP_DIR}/tzdata-with-posix-alias" .
+"${python3_cmd}" "${normalizer}" "${TMP_DIR}/tzdata-with-posix-alias.tar.bz2"
+mkdir "${TMP_DIR}/normalized-existing"
+tar -xjf "${TMP_DIR}/tzdata-with-posix-alias.tar.bz2" -C "${TMP_DIR}/normalized-existing" \
+	./usr/share/zoneinfo/posix
+if [ -L "${TMP_DIR}/normalized-existing/usr/share/zoneinfo/posix/UTC" ]; then
+	fail 'Existing POSIX timezone alias was not materialized'
+fi
+if [ "$(cat "${TMP_DIR}/normalized-existing/usr/share/zoneinfo/posix/UTC")" != 'TZif existing timezone' ]; then
+	fail 'Failed to preserve an existing POSIX timezone alias'
+fi
+
 cp "${TMP_DIR}/tzdata-without-posix.tar.bz2" "${TMP_DIR}/invalid-suffix.tbz"
 if "${python3_cmd}" "${normalizer}" "${TMP_DIR}/invalid-suffix.tbz" >/dev/null 2>&1; then
 	fail 'Normalizer accepted a package without the required suffix'

--- a/tests/update-tzdata-package-info.sh
+++ b/tests/update-tzdata-package-info.sh
@@ -42,7 +42,8 @@ python3_cmd="${PYTHON3:-python3}"
 if ! command -v "${python3_cmd}" >/dev/null 2>&1; then
 	fail "Selected Python 3 interpreter is unavailable: ${python3_cmd}"
 fi
-"${python3_cmd}" "${REPO_DIR}/tools/normalize-tzdata-package.py" "${TMP_DIR}/tzdata-without-posix.tar.bz2"
+normalizer="${REPO_DIR}/tools/normalize-tzdata-package.py"
+"${python3_cmd}" "${normalizer}" "${TMP_DIR}/tzdata-without-posix.tar.bz2"
 if ! tar -xOf "${TMP_DIR}/tzdata-without-posix.tar.bz2" ./usr/share/zoneinfo/posix/Etc/UTC |
 	grep -q '^TZif test timezone$'; then
 	fail 'Failed to add the installer-compatible POSIX timezone payload'
@@ -63,6 +64,30 @@ if ! tar -xOf "${TMP_DIR}/tzdata-without-posix.tar.bz2" ./.PKGINFO |
 	grep -q '^package metadata$'; then
 	fail 'Timezone normalization did not preserve package metadata'
 fi
+
+cp "${TMP_DIR}/tzdata-without-posix.tar.bz2" "${TMP_DIR}/invalid-suffix.tbz"
+if "${python3_cmd}" "${normalizer}" "${TMP_DIR}/invalid-suffix.tbz" >/dev/null 2>&1; then
+	fail 'Normalizer accepted a package without the required suffix'
+fi
+ln -s tzdata-without-posix.tar.bz2 "${TMP_DIR}/linked-package.tar.bz2"
+if "${python3_cmd}" "${normalizer}" "${TMP_DIR}/linked-package.tar.bz2" >/dev/null 2>&1; then
+	fail 'Normalizer accepted a symbolic-link package path'
+fi
+"${python3_cmd}" -c '
+import io
+import sys
+import tarfile
+
+with tarfile.open(sys.argv[1], "w:bz2") as package:
+	member = tarfile.TarInfo("../escape")
+	payload = b"TZif unsafe timezone\n"
+	member.size = len(payload)
+	package.addfile(member, io.BytesIO(payload))
+' "${TMP_DIR}/unsafe-member.tar.bz2"
+if "${python3_cmd}" "${normalizer}" "${TMP_DIR}/unsafe-member.tar.bz2" >/dev/null 2>&1; then
+	fail 'Normalizer accepted an unsafe archive member path'
+fi
+[ ! -e "${TMP_DIR}/escape" ] || fail 'Unsafe archive member escaped the test directory'
 
 printf '%s\n' 'not package metadata' >"${TMP_DIR}/README"
 printf '%s\n' 'not a tar archive' >"${TMP_DIR}/corrupt.tar"

--- a/tools/code-quality.sh
+++ b/tools/code-quality.sh
@@ -261,6 +261,7 @@ run_check 'Installer DNS input failure regression' sh tests/installer-dns-input-
 run_check 'Installer WebUI port failure regression' sh tests/installer-web-port-failure.sh
 run_check 'Installer timezone failure regression' sh tests/installer-timezone-failure.sh
 run_check 'tzdata package metadata regression' sh tests/update-tzdata-package-info.sh
+run_check 'tzdata normalizer Python regression' "${PYTHON3:-python3}" tests/normalize-tzdata-package.py
 run_check 'Installer branch switch cancellation regression' sh tests/installer-branch-switch-cancel.sh
 run_check 'Installer setting confirmation failure regression' sh tests/installer-setting-confirmation-failure.sh
 run_check 'Installer confirmation failure propagation regression' sh tests/installer-confirmation-failure-propagation.sh

--- a/tools/normalize-tzdata-package.py
+++ b/tools/normalize-tzdata-package.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python3
+"""Add the POSIX timezone tree expected by the router installer when absent."""
+
+import copy
+import os
+import posixpath
+import sys
+import tarfile
+import tempfile
+
+
+ZONEINFO_PREFIX = "usr/share/zoneinfo/"
+POSIX_PREFIX = f"{ZONEINFO_PREFIX}posix/"
+
+
+def normalized_member_name(name):
+	return posixpath.normpath(name.removeprefix("./"))
+
+
+def validate_member(member):
+	name = normalized_member_name(member.name)
+	if member.name.startswith("/") or name == ".." or name.startswith("../"):
+		raise SystemExit(f"Unsafe archive member path: {member.name}")
+	if member.issym() or member.islnk():
+		link_name = normalized_member_name(member.linkname)
+		if member.linkname.startswith("/"):
+			raise SystemExit(f"Unsafe archive link: {member.name} -> {member.linkname}")
+		if member.issym():
+			link_name = posixpath.normpath(posixpath.join(posixpath.dirname(name), member.linkname))
+		if link_name == ".." or link_name.startswith("../"):
+			raise SystemExit(f"Unsafe archive link: {member.name} -> {member.linkname}")
+
+
+def is_timezone_file(package, member):
+	if not member.isfile():
+		return False
+	stream = package.extractfile(member)
+	return stream is not None and stream.read(4) == b"TZif"
+
+
+def link_target(member):
+	name = normalized_member_name(member.name)
+	target = normalized_member_name(member.linkname)
+	if member.issym():
+		target = posixpath.normpath(posixpath.join(posixpath.dirname(name), member.linkname))
+	return target
+
+
+def main(archive):
+	directory = os.path.dirname(os.path.abspath(archive))
+	with tarfile.open(archive, "r:bz2") as package:
+		members = package.getmembers()
+		for member in members:
+			validate_member(member)
+		if any(normalized_member_name(member.name).startswith(POSIX_PREFIX) and member.isfile() for member in members):
+			return
+
+		timezone_names = {
+			normalized_member_name(member.name)
+			for member in members
+			if normalized_member_name(member.name).startswith(ZONEINFO_PREFIX)
+			and is_timezone_file(package, member)
+		}
+		while True:
+			linked_names = {
+				normalized_member_name(member.name)
+				for member in members
+				if (member.issym() or member.islnk()) and link_target(member) in timezone_names
+			}
+			new_names = linked_names - timezone_names
+			if not new_names:
+				break
+			timezone_names.update(new_names)
+		if not timezone_names:
+			raise SystemExit(f"Package has no usable {ZONEINFO_PREFIX} timezone payload: {archive}")
+
+		with tempfile.NamedTemporaryFile(dir=directory, delete=False) as temporary:
+			temporary_name = temporary.name
+	try:
+		with tarfile.open(archive, "r:bz2") as package, tarfile.open(temporary_name, "w:bz2") as output:
+			members = package.getmembers()
+			for member in members:
+				stream = package.extractfile(member) if member.isfile() else None
+				output.addfile(member, stream)
+			for member in members:
+				name = normalized_member_name(member.name)
+				is_timezone_directory = member.isdir() and (
+					name == ZONEINFO_PREFIX.rstrip("/") or name.startswith(ZONEINFO_PREFIX)
+				) and any(
+					timezone_name.startswith(f"{name}/") for timezone_name in timezone_names
+				)
+				if name not in timezone_names and not is_timezone_directory:
+					continue
+				posix_member = copy.copy(member)
+				relative_name = "" if name == ZONEINFO_PREFIX.rstrip("/") else name.removeprefix(ZONEINFO_PREFIX)
+				posix_member.name = f"./{POSIX_PREFIX}{relative_name}"
+				if member.islnk():
+					posix_member.linkname = f"./{POSIX_PREFIX}{link_target(member).removeprefix(ZONEINFO_PREFIX)}"
+				stream = package.extractfile(member) if member.isfile() else None
+				output.addfile(posix_member, stream)
+		os.replace(temporary_name, archive)
+	finally:
+		if os.path.exists(temporary_name):
+			os.unlink(temporary_name)
+
+
+if __name__ == "__main__":
+	if len(sys.argv) != 2:
+		raise SystemExit(f"Usage: {sys.argv[0]} PACKAGE")
+	main(sys.argv[1])

--- a/tools/normalize-tzdata-package.py
+++ b/tools/normalize-tzdata-package.py
@@ -99,30 +99,24 @@ def timezone_names(package, members):
 		names.update(new_names)
 
 
-def has_usable_posix_payload(package, members):
-	"""Return whether POSIX contains TZif data or an alias resolving to it."""
+def has_usable_posix_payload(package, members, names):
+	"""Return whether POSIX has materialized data for every selected timezone."""
 	if any(
 		(member.issym() or member.islnk())
 		and normalized_member_name(member.name).startswith(POSIX_PREFIX)
 		for member in members
 	):
 		return False
-	names = {
+	posix_names = {
 		normalized_member_name(member.name)
 		for member in members
-		if not normalized_member_name(member.name).startswith(RIGHT_PREFIX)
+		if normalized_member_name(member.name).startswith(POSIX_PREFIX)
 		and is_timezone_file(package, member)
 	}
-	while True:
-		linked_names = {
-			normalized_member_name(member.name)
-			for member in members
-			if (member.issym() or member.islnk()) and link_target(member) in names
-		}
-		new_names = linked_names - names
-		if not new_names:
-			return any(name.startswith(POSIX_PREFIX) for name in names)
-		names.update(new_names)
+	expected_names = {
+		f"{POSIX_PREFIX}{strip_prefix(name, ZONEINFO_PREFIX)}" for name in names
+	}
+	return expected_names.issubset(posix_names)
 
 
 def copy_member(package, output, member, output_member=None):
@@ -211,11 +205,11 @@ def main(archive):
 		members = package.getmembers()
 		for member in members:
 			validate_member(member)
-		if has_usable_posix_payload(package, members):
-			return
 		names = timezone_names(package, members)
-	if not names:
-		raise SystemExit(f"Package has no usable {ZONEINFO_PREFIX} timezone payload: {archive}")
+		if not names:
+			raise SystemExit(f"Package has no usable {ZONEINFO_PREFIX} timezone payload: {archive}")
+		if has_usable_posix_payload(package, members, names):
+			return
 	rewrite_archive(archive, members, names)
 
 

--- a/tools/normalize-tzdata-package.py
+++ b/tools/normalize-tzdata-package.py
@@ -35,7 +35,12 @@ def is_timezone_file(package, member):
 	if not member.isfile():
 		return False
 	stream = package.extractfile(member)
-	return stream is not None and stream.read(4) == b"TZif"
+	if stream is None:
+		return False
+	try:
+		return stream.read(4) == b"TZif"
+	finally:
+		stream.close()
 
 
 def link_target(member):

--- a/tools/normalize-tzdata-package.py
+++ b/tools/normalize-tzdata-package.py
@@ -14,25 +14,34 @@ POSIX_PREFIX = f"{ZONEINFO_PREFIX}posix/"
 RIGHT_PREFIX = f"{ZONEINFO_PREFIX}right/"
 
 
+def strip_prefix(value, prefix):
+	"""Return value without prefix when it starts with that prefix."""
+	return value[len(prefix) :] if value.startswith(prefix) else value
+
+
 def normalized_member_name(name):
-	return posixpath.normpath(name.removeprefix("./"))
+	"""Normalize an archive member name without treating it as a host path."""
+	return posixpath.normpath(strip_prefix(name, "./"))
 
 
 def validate_member(member):
+	"""Reject archive members and links that can escape the archive root."""
 	name = normalized_member_name(member.name)
 	if member.name.startswith("/") or name == ".." or name.startswith("../"):
 		raise SystemExit(f"Unsafe archive member path: {member.name}")
-	if member.issym() or member.islnk():
-		link_name = normalized_member_name(member.linkname)
-		if member.linkname.startswith("/"):
-			raise SystemExit(f"Unsafe archive link: {member.name} -> {member.linkname}")
-		if member.issym():
-			link_name = posixpath.normpath(posixpath.join(posixpath.dirname(name), member.linkname))
-		if link_name == ".." or link_name.startswith("../"):
-			raise SystemExit(f"Unsafe archive link: {member.name} -> {member.linkname}")
+	if not (member.issym() or member.islnk()):
+		return
+	link_name = normalized_member_name(member.linkname)
+	if member.linkname.startswith("/"):
+		raise SystemExit(f"Unsafe archive link: {member.name} -> {member.linkname}")
+	if member.issym():
+		link_name = posixpath.normpath(posixpath.join(posixpath.dirname(name), member.linkname))
+	if link_name == ".." or link_name.startswith("../"):
+		raise SystemExit(f"Unsafe archive link: {member.name} -> {member.linkname}")
 
 
 def is_timezone_file(package, member):
+	"""Return whether a regular archive member starts with the TZif magic."""
 	if not member.isfile():
 		return False
 	stream = package.extractfile(member)
@@ -45,6 +54,7 @@ def is_timezone_file(package, member):
 
 
 def link_target(member):
+	"""Return the normalized in-archive target of a link member."""
 	name = normalized_member_name(member.name)
 	target = normalized_member_name(member.linkname)
 	if member.issym():
@@ -53,81 +63,120 @@ def link_target(member):
 
 
 def linked_file(member, members_by_name):
+	"""Resolve an in-archive link chain to its regular member."""
+	visited = set()
 	while member.issym() or member.islnk():
-		member = members_by_name[link_target(member)]
+		name = normalized_member_name(member.name)
+		if name in visited:
+			raise SystemExit(f"Cyclic archive link: {name}")
+		visited.add(name)
+		target = link_target(member)
+		if target not in members_by_name:
+			raise SystemExit(f"Missing archive link target: {name} -> {target}")
+		member = members_by_name[target]
 	return member
 
 
+def timezone_names(package, members):
+	"""Collect usable timezone files and aliases, excluding special trees."""
+	names = {
+		normalized_member_name(member.name)
+		for member in members
+		if normalized_member_name(member.name).startswith(ZONEINFO_PREFIX)
+		and not normalized_member_name(member.name).startswith(RIGHT_PREFIX)
+		and not normalized_member_name(member.name).startswith(POSIX_PREFIX)
+		and is_timezone_file(package, member)
+	}
+	while True:
+		linked_names = {
+			normalized_member_name(member.name)
+			for member in members
+			if (member.issym() or member.islnk()) and link_target(member) in names
+		}
+		new_names = linked_names - names
+		if not new_names:
+			return names
+		names.update(new_names)
+
+
+def copy_member(package, output, member, output_member=None):
+	"""Copy one member and guarantee closure of its extracted data stream."""
+	stream = package.extractfile(member) if member.isfile() else None
+	try:
+		# Member paths were validated before this archive-to-archive copy. No host
+		# filesystem extraction occurs here.
+		output.addfile(output_member or member, stream)  # NOSONAR
+	finally:
+		if stream is not None:
+			stream.close()
+
+
+def is_timezone_directory(member, name, names):
+	"""Return whether a directory is needed by a selected timezone member."""
+	return member.isdir() and (
+		name == ZONEINFO_PREFIX.rstrip("/") or name.startswith(ZONEINFO_PREFIX)
+	) and any(timezone_name.startswith(f"{name}/") for timezone_name in names)
+
+
+def add_posix_members(package, output, members, names):
+	"""Append installer-compatible POSIX members to an output archive."""
+	members_by_name = {normalized_member_name(member.name): member for member in members}
+	for member in members:
+		name = normalized_member_name(member.name)
+		if name not in names and not is_timezone_directory(member, name, names):
+			continue
+		posix_member = copy.copy(member)
+		relative_name = "" if name == ZONEINFO_PREFIX.rstrip("/") else strip_prefix(name, ZONEINFO_PREFIX)
+		posix_member.name = f"./{POSIX_PREFIX}{relative_name}"
+		source_member = member
+		if member.issym() or member.islnk():
+			source_member = linked_file(member, members_by_name)
+			posix_member.type = tarfile.REGTYPE
+			posix_member.linkname = ""
+			posix_member.size = source_member.size
+		copy_member(package, output, source_member, posix_member)
+
+
+def validated_archive_path(archive):
+	"""Resolve and validate the caller-selected package before rewriting it."""
+	resolved = os.path.abspath(archive)
+	if not resolved.endswith(".tar.bz2"):
+		raise SystemExit(f"Package must use the .tar.bz2 suffix: {archive}")
+	if os.path.islink(resolved) or not os.path.isfile(resolved):
+		raise SystemExit(f"Package is not a regular file: {archive}")
+	return resolved
+
+
+def rewrite_archive(archive, members, names):
+	"""Rewrite a validated package atomically with its POSIX payload."""
+	directory = os.path.dirname(archive)
+	with tempfile.NamedTemporaryFile(dir=directory, delete=False) as temporary:  # NOSONAR
+		temporary_name = temporary.name
+	try:
+		# The CLI path is canonicalized and validated as a regular .tar.bz2 file.
+		with tarfile.open(archive, "r:bz2") as package, tarfile.open(temporary_name, "w:bz2") as output:  # NOSONAR
+			for member in members:
+				copy_member(package, output, member)
+			add_posix_members(package, output, members, names)
+		os.replace(temporary_name, archive)  # NOSONAR
+	finally:
+		if os.path.exists(temporary_name):
+			os.unlink(temporary_name)
+
+
 def main(archive):
-	directory = os.path.dirname(os.path.abspath(archive))
-	with tarfile.open(archive, "r:bz2") as package:
+	"""Validate and normalize one bzip2-compressed tzdata package."""
+	archive = validated_archive_path(archive)
+	with tarfile.open(archive, "r:bz2") as package:  # NOSONAR
 		members = package.getmembers()
 		for member in members:
 			validate_member(member)
 		if any(normalized_member_name(member.name).startswith(POSIX_PREFIX) and member.isfile() for member in members):
 			return
-
-		timezone_names = {
-			normalized_member_name(member.name)
-			for member in members
-			if normalized_member_name(member.name).startswith(ZONEINFO_PREFIX)
-			and not normalized_member_name(member.name).startswith(RIGHT_PREFIX)
-			and is_timezone_file(package, member)
-		}
-		while True:
-			linked_names = {
-				normalized_member_name(member.name)
-				for member in members
-				if (member.issym() or member.islnk()) and link_target(member) in timezone_names
-			}
-			new_names = linked_names - timezone_names
-			if not new_names:
-				break
-			timezone_names.update(new_names)
-		if not timezone_names:
-			raise SystemExit(f"Package has no usable {ZONEINFO_PREFIX} timezone payload: {archive}")
-
-		with tempfile.NamedTemporaryFile(dir=directory, delete=False) as temporary:
-			temporary_name = temporary.name
-	try:
-		with tarfile.open(archive, "r:bz2") as package, tarfile.open(temporary_name, "w:bz2") as output:
-			members = package.getmembers()
-			members_by_name = {normalized_member_name(member.name): member for member in members}
-			for member in members:
-				stream = package.extractfile(member) if member.isfile() else None
-				try:
-					output.addfile(member, stream)
-				finally:
-					if stream is not None:
-						stream.close()
-			for member in members:
-				name = normalized_member_name(member.name)
-				is_timezone_directory = member.isdir() and (
-					name == ZONEINFO_PREFIX.rstrip("/") or name.startswith(ZONEINFO_PREFIX)
-				) and any(
-					timezone_name.startswith(f"{name}/") for timezone_name in timezone_names
-				)
-				if name not in timezone_names and not is_timezone_directory:
-					continue
-				posix_member = copy.copy(member)
-				relative_name = "" if name == ZONEINFO_PREFIX.rstrip("/") else name.removeprefix(ZONEINFO_PREFIX)
-				posix_member.name = f"./{POSIX_PREFIX}{relative_name}"
-				source_member = member
-				if member.issym() or member.islnk():
-					source_member = linked_file(member, members_by_name)
-					posix_member.type = tarfile.REGTYPE
-					posix_member.linkname = ""
-					posix_member.size = source_member.size
-				stream = package.extractfile(source_member) if source_member.isfile() else None
-				try:
-					output.addfile(posix_member, stream)
-				finally:
-					if stream is not None:
-						stream.close()
-		os.replace(temporary_name, archive)
-	finally:
-		if os.path.exists(temporary_name):
-			os.unlink(temporary_name)
+		names = timezone_names(package, members)
+	if not names:
+		raise SystemExit(f"Package has no usable {ZONEINFO_PREFIX} timezone payload: {archive}")
+	rewrite_archive(archive, members, names)
 
 
 if __name__ == "__main__":

--- a/tools/normalize-tzdata-package.py
+++ b/tools/normalize-tzdata-package.py
@@ -11,6 +11,7 @@ import tempfile
 
 ZONEINFO_PREFIX = "usr/share/zoneinfo/"
 POSIX_PREFIX = f"{ZONEINFO_PREFIX}posix/"
+RIGHT_PREFIX = f"{ZONEINFO_PREFIX}right/"
 
 
 def normalized_member_name(name):
@@ -64,6 +65,7 @@ def main(archive):
 			normalized_member_name(member.name)
 			for member in members
 			if normalized_member_name(member.name).startswith(ZONEINFO_PREFIX)
+			and not normalized_member_name(member.name).startswith(RIGHT_PREFIX)
 			and is_timezone_file(package, member)
 		}
 		while True:

--- a/tools/normalize-tzdata-package.py
+++ b/tools/normalize-tzdata-package.py
@@ -86,7 +86,11 @@ def main(archive):
 			members = package.getmembers()
 			for member in members:
 				stream = package.extractfile(member) if member.isfile() else None
-				output.addfile(member, stream)
+				try:
+					output.addfile(member, stream)
+				finally:
+					if stream is not None:
+						stream.close()
 			for member in members:
 				name = normalized_member_name(member.name)
 				is_timezone_directory = member.isdir() and (
@@ -102,7 +106,11 @@ def main(archive):
 				if member.islnk():
 					posix_member.linkname = f"./{POSIX_PREFIX}{link_target(member).removeprefix(ZONEINFO_PREFIX)}"
 				stream = package.extractfile(member) if member.isfile() else None
-				output.addfile(posix_member, stream)
+				try:
+					output.addfile(posix_member, stream)
+				finally:
+					if stream is not None:
+						stream.close()
 		os.replace(temporary_name, archive)
 	finally:
 		if os.path.exists(temporary_name):

--- a/tools/normalize-tzdata-package.py
+++ b/tools/normalize-tzdata-package.py
@@ -99,6 +99,26 @@ def timezone_names(package, members):
 		names.update(new_names)
 
 
+def has_usable_posix_payload(package, members):
+	"""Return whether POSIX contains TZif data or an alias resolving to it."""
+	names = {
+		normalized_member_name(member.name)
+		for member in members
+		if not normalized_member_name(member.name).startswith(RIGHT_PREFIX)
+		and is_timezone_file(package, member)
+	}
+	while True:
+		linked_names = {
+			normalized_member_name(member.name)
+			for member in members
+			if (member.issym() or member.islnk()) and link_target(member) in names
+		}
+		new_names = linked_names - names
+		if not new_names:
+			return any(name.startswith(POSIX_PREFIX) for name in names)
+		names.update(new_names)
+
+
 def copy_member(package, output, member, output_member=None):
 	"""Copy one member and guarantee closure of its extracted data stream."""
 	stream = package.extractfile(member) if member.isfile() else None
@@ -156,6 +176,9 @@ def rewrite_archive(archive, members, names):
 		# The CLI path is canonicalized and validated as a regular .tar.bz2 file.
 		with tarfile.open(archive, "r:bz2") as package, tarfile.open(temporary_name, "w:bz2") as output:  # NOSONAR
 			for member in members:
+				name = normalized_member_name(member.name)
+				if name == POSIX_PREFIX.rstrip("/") or name.startswith(POSIX_PREFIX):
+					continue
 				copy_member(package, output, member)
 			add_posix_members(package, output, members, names)
 		os.replace(temporary_name, archive)  # NOSONAR
@@ -171,7 +194,7 @@ def main(archive):
 		members = package.getmembers()
 		for member in members:
 			validate_member(member)
-		if any(normalized_member_name(member.name).startswith(POSIX_PREFIX) and member.isfile() for member in members):
+		if has_usable_posix_payload(package, members):
 			return
 		names = timezone_names(package, members)
 	if not names:

--- a/tools/normalize-tzdata-package.py
+++ b/tools/normalize-tzdata-package.py
@@ -101,6 +101,12 @@ def timezone_names(package, members):
 
 def has_usable_posix_payload(package, members):
 	"""Return whether POSIX contains TZif data or an alias resolving to it."""
+	if any(
+		(member.issym() or member.islnk())
+		and normalized_member_name(member.name).startswith(POSIX_PREFIX)
+		for member in members
+	):
+		return False
 	names = {
 		normalized_member_name(member.name)
 		for member in members
@@ -170,6 +176,10 @@ def validated_archive_path(archive):
 def rewrite_archive(archive, members, names):
 	"""Rewrite a validated package atomically with its POSIX payload."""
 	directory = os.path.dirname(archive)
+	members_by_name = {normalized_member_name(member.name): member for member in members}
+	generated_names = {
+		f"{POSIX_PREFIX}{strip_prefix(name, ZONEINFO_PREFIX)}" for name in names
+	}
 	with tempfile.NamedTemporaryFile(dir=directory, delete=False) as temporary:  # NOSONAR
 		temporary_name = temporary.name
 	try:
@@ -178,6 +188,13 @@ def rewrite_archive(archive, members, names):
 			for member in members:
 				name = normalized_member_name(member.name)
 				if name == POSIX_PREFIX.rstrip("/") or name.startswith(POSIX_PREFIX):
+					if (member.issym() or member.islnk()) and name not in generated_names:
+						source_member = linked_file(member, members_by_name)
+						posix_member = copy.copy(member)
+						posix_member.type = tarfile.REGTYPE
+						posix_member.linkname = ""
+						posix_member.size = source_member.size
+						copy_member(package, output, source_member, posix_member)
 					continue
 				copy_member(package, output, member)
 			add_posix_members(package, output, members, names)

--- a/tools/normalize-tzdata-package.py
+++ b/tools/normalize-tzdata-package.py
@@ -52,6 +52,12 @@ def link_target(member):
 	return target
 
 
+def linked_file(member, members_by_name):
+	while member.issym() or member.islnk():
+		member = members_by_name[link_target(member)]
+	return member
+
+
 def main(archive):
 	directory = os.path.dirname(os.path.abspath(archive))
 	with tarfile.open(archive, "r:bz2") as package:
@@ -86,6 +92,7 @@ def main(archive):
 	try:
 		with tarfile.open(archive, "r:bz2") as package, tarfile.open(temporary_name, "w:bz2") as output:
 			members = package.getmembers()
+			members_by_name = {normalized_member_name(member.name): member for member in members}
 			for member in members:
 				stream = package.extractfile(member) if member.isfile() else None
 				try:
@@ -105,9 +112,13 @@ def main(archive):
 				posix_member = copy.copy(member)
 				relative_name = "" if name == ZONEINFO_PREFIX.rstrip("/") else name.removeprefix(ZONEINFO_PREFIX)
 				posix_member.name = f"./{POSIX_PREFIX}{relative_name}"
-				if member.islnk():
-					posix_member.linkname = f"./{POSIX_PREFIX}{link_target(member).removeprefix(ZONEINFO_PREFIX)}"
-				stream = package.extractfile(member) if member.isfile() else None
+				source_member = member
+				if member.issym() or member.islnk():
+					source_member = linked_file(member, members_by_name)
+					posix_member.type = tarfile.REGTYPE
+					posix_member.linkname = ""
+					posix_member.size = source_member.size
+				stream = package.extractfile(source_member) if source_member.isfile() else None
 				try:
 					output.addfile(posix_member, stream)
 				finally:

--- a/tools/update-tzdata.sh
+++ b/tools/update-tzdata.sh
@@ -173,6 +173,7 @@ download_package() {
 		*.zst) zstd --decompress --stdout "${upstream_file}" | bzip2 -9 >"${output_file}" ;;
 	esac
 	tar -tjf "${output_file}" >/dev/null
+	"${PYTHON3}" "${SCRIPT_DIR}/normalize-tzdata-package.py" "${output_file}"
 	if ! tar -tjf "${output_file}" |
 		awk '/^\.\/usr\/share\/zoneinfo\/posix\/./ && !/\/$/ { found = 1 } END { exit !found }'; then
 		printf 'Package has no usable ./usr/share/zoneinfo/posix payload: %s\n' "${filename}" >&2


### PR DESCRIPTION
### Motivation

- Some Arch Linux ARM tzdata packages omit the `usr/share/zoneinfo/posix` tree expected by the installer, causing the tzdata workflow and installer extraction to fail. 
- The change ensures CI-host-side normalization so signed upstream archives remain verified while providing the installer-compatible POSIX payload.

### Description

- Add `tools/normalize-tzdata-package.py`, a host-side helper that validates tar member paths/links, detects real `TZif` timezone files, preserves aliases, and synthesizes `usr/share/zoneinfo/posix/` entries when missing. 
- Invoke the normalizer from `tools/update-tzdata.sh` immediately after converting upstream packages to bzip2 and before the existing POSIX-payload verification. 
- Extend `tests/update-tzdata-package-info.sh` with a regression that builds a tzdata package missing `posix/`, runs the normalizer, and verifies that the POSIX payload, aliases, and `.PKGINFO` are preserved. 
- Add the new helper to the `.github/workflows/update-tzdata.yml` path filter so workflow changes trigger CI as expected.

### Testing

- `sh -n tools/update-tzdata.sh tests/update-tzdata-package-info.sh` — passed. 
- `sh tests/update-tzdata-package-info.sh` — passed (regression added to validate normalization). 
- `python3 -m py_compile tools/normalize-tzdata-package.py` — passed. 
- `sh tests/coderabbit-and-workflow-config-checks.sh` — passed (workflow/path checks). 
- `git diff --check` and other repository checks — passed. 
- `shellcheck` and `busybox ash` validations were not executed because those tools are unavailable in the validation environment (not a failing test, noted as environment warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d39c5c2f48329bf5f2a12bb6e4ab7)