### PR TITLE
Safely recompress .xz tzdata packages, harden POSIX timezone validation, and tighten tests

### DIFF
--- a/tests/installer-dns-environment-failure.sh
+++ b/tests/installer-dns-environment-failure.sh
@@ -1410,6 +1410,9 @@ nvram_transaction_set dnspriv_enable 0 || fail 'DNS restore cleanup transaction 
 nvram_transaction_apply restart_dnsmasq 1 || fail 'DNS restore cleanup transaction apply failed'
 _DNS_NVRAM_SAVED=1
 FAIL_SNAPSHOT_REMOVE=1
+# Leave enough simulated readiness time for the background lookup to finish on
+# loaded CI hosts; this case exercises snapshot cleanup, not timeout handling.
+DNS_ENV_RECOVERY_TIMEOUT=10
 check_dns_environment 1 || fail 'completed DNS restore failed because best-effort snapshot cleanup was interrupted'
 [ "${_DNS_NVRAM_SAVED}" = 0 ] || fail 'completed DNS restore retained the saved-state marker'
 [ -d "${NVRAM_TRANSACTION_DIR}" ] || fail 'DNS restore cleanup injection did not retain the inert snapshot'

--- a/tests/update-tzdata-package-info.sh
+++ b/tests/update-tzdata-package-info.sh
@@ -48,10 +48,25 @@ if ! cmp "${TMP_DIR}/tzdata.tar" "${TMP_DIR}/recompressed.tar"; then
 fi
 
 UPDATE_SCRIPT="${REPO_DIR}/tools/update-tzdata.sh"
-grep -Fq '*.xz) xz -d -c "${upstream_file}" | bzip2 -9 >"${output_file}" ;;' \
-	"${UPDATE_SCRIPT}" || fail 'Update script does not preserve the xz tar stream during recompression'
+grep -Fq '*.xz) recompress_xz_package "${upstream_file}" "${output_file}" ;;' \
+	"${UPDATE_SCRIPT}" || fail 'Update script does not verify xz decompression before recompression'
 if grep -Eq '(xz|bzip2) -dc([[:space:]]|$)' "${UPDATE_SCRIPT}" "${0}"; then
 	fail 'Combined decompression flags are incompatible with the BusyBox applets'
+fi
+awk 'found { print } /^recompress_xz_package\(\) \{/ { found = 1; print } found && /^}/ { exit }' \
+	"${UPDATE_SCRIPT}" >"${TMP_DIR}/recompress-xz-package.sh"
+. "${TMP_DIR}/recompress-xz-package.sh"
+cp "${TMP_DIR}/tzdata.pkg.tar.xz" "${TMP_DIR}/malformed.pkg.tar.xz"
+printf '\3757zXZ\000' >>"${TMP_DIR}/malformed.pkg.tar.xz"
+printf '%s\n' 'stale output' >"${TMP_DIR}/malformed.pkg.tar.bz2"
+printf '%s\n' 'stale temporary stream' >"${TMP_DIR}/malformed.pkg.tar.bz2.tar"
+if recompress_xz_package "${TMP_DIR}/malformed.pkg.tar.xz" \
+	"${TMP_DIR}/malformed.pkg.tar.bz2" >/dev/null 2>&1; then
+	fail 'Malformed trailing XZ data unexpectedly passed recompression'
+fi
+if [ -e "${TMP_DIR}/malformed.pkg.tar.bz2" ] || \
+	[ -e "${TMP_DIR}/malformed.pkg.tar.bz2.tar" ]; then
+	fail 'Failed XZ decompression left conversion files behind'
 fi
 grep -Fq 'download_package aarch64 aarch64' "${UPDATE_SCRIPT}" ||
 	fail 'Update script does not publish the aarch64 package'
@@ -83,12 +98,27 @@ if "${python3_cmd}" "${TMP_DIR}/validate-package.py" \
 	"${TMP_DIR}/symlink-posix.tar.bz2" >/dev/null 2>&1; then
 	fail 'Archive with only a safe POSIX timezone symbolic link unexpectedly passed validation'
 fi
+mkdir -p "${TMP_DIR}/alias-posix/usr/share/zoneinfo/posix/Etc"
+printf 'TZif POSIX test timezone\n' >"${TMP_DIR}/alias-posix/usr/share/zoneinfo/posix/Etc/UTC"
+ln -s Etc/UTC "${TMP_DIR}/alias-posix/usr/share/zoneinfo/posix/UTC"
+tar -cjf "${TMP_DIR}/alias-posix.tar.bz2" -C "${TMP_DIR}/alias-posix" .
+if "${python3_cmd}" "${TMP_DIR}/validate-package.py" \
+	"${TMP_DIR}/alias-posix.tar.bz2" >/dev/null 2>&1; then
+	fail 'Archive with a selectable POSIX timezone alias unexpectedly passed validation'
+fi
 mkdir -p "${TMP_DIR}/empty-posix/usr/share/zoneinfo/posix/Etc"
 : >"${TMP_DIR}/empty-posix/usr/share/zoneinfo/posix/Etc/UTC"
 tar -cjf "${TMP_DIR}/empty-posix.tar.bz2" -C "${TMP_DIR}/empty-posix" .
 if "${python3_cmd}" "${TMP_DIR}/validate-package.py" \
 	"${TMP_DIR}/empty-posix.tar.bz2" >/dev/null 2>&1; then
 	fail 'Archive with only an empty POSIX timezone file unexpectedly passed validation'
+fi
+mkdir -p "${TMP_DIR}/invalid-posix/usr/share/zoneinfo/posix/Etc"
+printf 'not timezone data\n' >"${TMP_DIR}/invalid-posix/usr/share/zoneinfo/posix/Etc/UTC"
+tar -cjf "${TMP_DIR}/invalid-posix.tar.bz2" -C "${TMP_DIR}/invalid-posix" .
+if "${python3_cmd}" "${TMP_DIR}/validate-package.py" \
+	"${TMP_DIR}/invalid-posix.tar.bz2" >/dev/null 2>&1; then
+	fail 'Archive with invalid POSIX timezone data unexpectedly passed validation'
 fi
 if ! "${python3_cmd}" "${TMP_DIR}/validate-package.py" \
 	"${TMP_DIR}/tzdata.pkg.tar.bz2"; then

--- a/tools/update-tzdata.sh
+++ b/tools/update-tzdata.sh
@@ -128,6 +128,24 @@ discover_package_filename() {
 	return 1
 }
 
+recompress_xz_package() {
+	local decompressed_file output_file upstream_file
+	upstream_file="$1"
+	output_file="$2"
+	decompressed_file="${output_file}.tar"
+
+	rm -f "${decompressed_file}" "${output_file}"
+	if ! xz -d -c "${upstream_file}" >"${decompressed_file}"; then
+		rm -f "${decompressed_file}" "${output_file}"
+		return 1
+	fi
+	if ! bzip2 -9 <"${decompressed_file}" >"${output_file}"; then
+		rm -f "${decompressed_file}" "${output_file}"
+		return 1
+	fi
+	rm -f "${decompressed_file}"
+}
+
 download_package() {
 	local architecture output_arch filename
 	local upstream_file package_info package_version package_arch output_file
@@ -169,7 +187,7 @@ download_package() {
 	output_file="${stage_dir}/tzdata-${package_version}-${output_arch}.pkg.tar.bz2"
 	case "${upstream_file}" in
 		*.bz2) cp "${upstream_file}" "${output_file}" ;;
-		*.xz) xz -d -c "${upstream_file}" | bzip2 -9 >"${output_file}" ;;
+		*.xz) recompress_xz_package "${upstream_file}" "${output_file}" ;;
 		*.zst) zstd --decompress --stdout "${upstream_file}" | bzip2 -9 >"${output_file}" ;;
 	esac
 	tar -tjf "${output_file}" >/dev/null
@@ -185,8 +203,12 @@ with tarfile.open(archive, "r:bz2") as package:
         normalized_name = posixpath.normpath(member.name)
         if member.name.startswith("/") or normalized_name == ".." or normalized_name.startswith("../"):
             raise SystemExit(f"Unsafe archive member path: {member.name}")
-        if (member.isfile() and member.size > 0 and
-                normalized_name.startswith("usr/share/zoneinfo/posix/")):
+        if normalized_name.startswith("usr/share/zoneinfo/posix/") and not member.isdir():
+            if not member.isfile():
+                raise SystemExit(f"POSIX timezone is not a regular file: {member.name}")
+            timezone = package.extractfile(member)
+            if timezone is None or timezone.read(4) != b"TZif":
+                raise SystemExit(f"POSIX timezone has invalid TZif data: {member.name}")
             has_posix_timezone = True
         if member.issym():
             link_path = posixpath.normpath(posixpath.join(posixpath.dirname(normalized_name), member.linkname))


### PR DESCRIPTION
### Motivation
- Ensure recompression of upstream `.xz` tzdata packages fails cleanly without leaving temporary files when the upstream stream is malformed.
- Harden validation so packages must contain a usable POSIX timezone as a regular file beginning with the `TZif` magic and reject aliases or invalid payloads.
- Reduce CI flakiness in DNS environment tests by giving background lookups extra simulated readiness time.

### Description
- Add `recompress_xz_package()` to `tools/update-tzdata.sh` which decompresses `.xz` to a temporary tar, recompresses to `.bz2`, and removes intermediates on error.
- Replace the direct `xz | bzip2` pipeline with `recompress_xz_package` when handling `.xz` upstream files and keep existing `.bz2`/`.zst` flows.
- Strengthen the Python-based package validator to require POSIX timezone members to be regular files whose first bytes equal `TZif`, and to reject unsafe link targets and non-regular POSIX entries.
- Update `tests/update-tzdata-package-info.sh` to assert use of `recompress_xz_package`, verify it rejects malformed trailing XZ data and does not leave output files, and add test cases for POSIX alias and invalid POSIX timezone payloads.
- Add a short comment and set `DNS_ENV_RECOVERY_TIMEOUT=10` in `tests/installer-dns-environment-failure.sh` to allow background lookups to finish on loaded CI hosts.

### Testing
- Ran `tests/update-tzdata-package-info.sh`, which exercises recompression, POSIX timezone validation, and safety checks, and it completed successfully.
- Ran `tests/installer-dns-environment-failure.sh` with the adjusted timeout to validate snapshot cleanup and DNS recovery behavior, and it completed successfully.
- The embedded Python validator checks ran as part of the scripts and produced the expected failures for malformed and unsafe archives.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8e3d0851e48329a40d986e5cfdede2)