### PR TITLE
tests: repair CI regressions — add nvram lock stubs and fix IPSET version-gate expectation

### DIFF
--- a/tests/installer-dns-input-failure.sh
+++ b/tests/installer-dns-input-failure.sh
@@ -90,6 +90,8 @@ installer_lan_domain_set() { nvram set "lan_domain=$1"; }
 installer_lan_domain_restore() { :; }
 # nvram_transaction_finalize_setup_pair completes the NVRAM setup transaction successfully.
 nvram_transaction_finalize_setup_pair() { return 0; }
+# nvram_transaction_lock_owned reports that this isolated setup fixture owns its transaction lock.
+nvram_transaction_lock_owned() { return 0; }
 # nvram_transaction_setup_committed reports whether the setup commit marker exists.
 nvram_transaction_setup_committed() { [ -f "${BASE_DIR}/.AdGuardHome.nvram/setup-committed" ]; }
 # nvram_transaction_setup_files_begin starts a setup-file transaction by recording the current configuration, YAML, and original YAML files, including markers for files that are absent.

--- a/tests/installer-lan-startup-generation.sh
+++ b/tests/installer-lan-startup-generation.sh
@@ -94,6 +94,8 @@ installer_lan_domain_set() { nvram set "lan_domain=$1"; }
 installer_lan_domain_restore() { :; }
 # nvram_transaction_finalize_setup_pair completes the simulated NVRAM setup transaction successfully.
 nvram_transaction_finalize_setup_pair() { return 0; }
+# nvram_transaction_lock_owned reports that this isolated setup fixture owns its transaction lock.
+nvram_transaction_lock_owned() { return 0; }
 # nvram_transaction_setup_committed reports whether the setup commit marker exists.
 nvram_transaction_setup_committed() { [ -f "${BASE_DIR}/.AdGuardHome.nvram/setup-committed" ]; }
 # nvram_transaction_setup_files_begin starts an NVRAM setup-files transaction.

--- a/tests/installer-staged-yaml-validation.sh
+++ b/tests/installer-staged-yaml-validation.sh
@@ -85,6 +85,8 @@ installer_lan_domain_set() { nvram set "lan_domain=$1"; }
 installer_lan_domain_restore() { :; }
 # nvram_transaction_finalize_setup_pair finalizes the NVRAM setup transaction successfully.
 nvram_transaction_finalize_setup_pair() { return 0; }
+# nvram_transaction_lock_owned reports that this isolated setup fixture owns its transaction lock.
+nvram_transaction_lock_owned() { return 0; }
 # nvram_transaction_setup_committed reports whether the setup commit marker exists.
 nvram_transaction_setup_committed() { [ -f "${BASE_DIR}/.AdGuardHome.nvram/setup-committed" ]; }
 # nvram_transaction_setup_files_begin starts the NVRAM setup-files transaction.

--- a/tests/installer-web-port-failure.sh
+++ b/tests/installer-web-port-failure.sh
@@ -169,6 +169,8 @@ nvram_transaction_finalize_setup_pair() {
 }
 # nvram_transaction_setup_committed reports whether the setup commit marker exists.
 nvram_transaction_setup_committed() { [ -f "${BASE_DIR}/.AdGuardHome.nvram/setup-committed" ]; }
+# nvram_transaction_lock_owned reports that this isolated setup fixture owns its transaction lock.
+nvram_transaction_lock_owned() { return 0; }
 # nvram_transaction_setup_files_begin creates a rollback journal containing snapshots of the YAML and configuration files, and records markers for files that are absent.
 nvram_transaction_setup_files_begin() {
 	local journal_root source target

--- a/tests/ipset-version-gate.sh
+++ b/tests/ipset-version-gate.sh
@@ -125,7 +125,7 @@ run_start_case 'AdGuard Home, version v0.107.48' 0 'lock IPSet_Disable_Managed_F
 IPSET_CONFIG=YES
 CONFIG_IPSET="${IPSET_CONFIG}"
 INSTALL_MODE=lan
-run_case 'AdGuard Home, version v0.107.48' 0 ''
+run_case 'AdGuard Home, version v0.107.48' 0 'lock IPSet_Disable_Managed_For_Start_Locked'
 run_start_case 'AdGuard Home, version v0.107.48' 0 'IPSet_Disable_Managed'
 DISABLE_STATUS=1
 run_start_case 'AdGuard Home, version v0.107.48' 0 'IPSet_Disable_Managed' 1


### PR DESCRIPTION
### Motivation

- CI and local regression runs showed failing/verbose test output from missing `nvram_transaction_lock_owned` stubs in isolated test fixtures and an incorrect expectation in the IPSET version-gate test for AdGuard Home v0.107.48 in LAN mode.

### Description

- Add `nvram_transaction_lock_owned() { return 0; }` to the isolated test fixtures in `tests/installer-lan-startup-generation.sh`, `tests/installer-staged-yaml-validation.sh`, `tests/installer-dns-input-failure.sh`, and `tests/installer-web-port-failure.sh` so setup-journal and transaction ownership checks run cleanly in the test harness.
- Update `tests/ipset-version-gate.sh` to expect the fail-closed managed-IPSET disable lock (`lock IPSet_Disable_Managed_For_Start_Locked`) when exercising the `run_case` for `AdGuard Home, version v0.107.48` in LAN-mode scenarios.
- Keep changes narrowly scoped to test fixtures and test expectations to avoid modifying runtime or installer behavior.

### Testing

- Ran `sh tests/ipset-version-gate.sh` and it passed the managed IPSET gating checks for the targeted versions.
- Ran `sh` on `tests/installer-lan-startup-generation.sh`, `tests/installer-staged-yaml-validation.sh`, `tests/installer-dns-input-failure.sh`, and `tests/installer-web-port-failure.sh` and each test passed under the local harness.
- Performed a syntax check (`sh -n`) on the modified test scripts and ran `sh tools/code-quality.sh`, which reported the repaired regressions as passing while the overall invocation returned nonzero due to missing host validation tools (`zstd`, `shellcheck`, and `shfmt`) on the validation host.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a90257493f0832991d42030852f79e9)