### PR TITLE
test: reliably record umount in dnsmasq LAN-mode tests to fix CI regression

### DIFF
--- a/tests/dnsmasq-lan-mode.sh
+++ b/tests/dnsmasq-lan-mode.sh
@@ -53,11 +53,6 @@ case "$1" in
 esac
 EOF_PIDOF
 chmod 700 "${BIN_DIR}/pidof" || fail 'could not make pidof stub executable'
-cat >"${BIN_DIR}/umount" <<'EOF_UMOUNT' || fail 'could not write umount stub'
-#!/bin/sh
-printf '%s\n' "$1" >>"${UMOUNT_CALLS_FILE}"
-EOF_UMOUNT
-chmod 700 "${BIN_DIR}/umount" || fail 'could not make umount stub executable'
 PATH="${BIN_DIR}:${PATH}"
 export PATH
 
@@ -107,6 +102,12 @@ resolv_conf_uses_rom() {
 # resolv_conf_is_tmp_mount determines whether resolv.conf is mounted from a temporary filesystem.
 resolv_conf_is_tmp_mount() {
 	[ "${RESOLV_CONF_TMP_MOUNT}" = '1' ]
+}
+
+# umount records cleanup requests without relying on PATH interception. BusyBox
+# ash can execute an applet directly instead of the same-named test stub.
+umount() {
+	printf '%s\n' "$1" >>"${UMOUNT_CALLS_FILE}"
 }
 
 # dns_handoff_is_active determines whether DNS handoff is active.


### PR DESCRIPTION
### Motivation

- Fix a CI/regression pathway where BusyBox `ash` can invoke the built-in `umount` applet (bypassing a PATH-installed test stub) and cause the `dnsmasq` LAN-mode test to falsely report that `/tmp/resolv.conf` was not unmounted.

### Description

- Replace the PATH-based `umount` test stub with a deterministic shell `umount()` function in `tests/dnsmasq-lan-mode.sh` that appends the target path to `UMOUNT_CALLS_FILE`, and remove the previously written `${BIN_DIR}/umount` fixture while preserving the existing `pidof` PATH stub; change committed as `e4cc4f9`.

### Testing

- Ran `sh -n tests/dnsmasq-lan-mode.sh`, `sh tests/dnsmasq-lan-mode.sh`, and the nearby regression suites (`tests/installer-event-script-modes.sh`, `tests/installer-event-script-transactions.sh`, `tests/installer-cli-lan-mode.sh`, `tests/installer-ipset-*.sh`, `tests/adguardhome-runtime-mode-helpers.sh`, `tests/ipset-lan-mode.sh`, `tests/installer-single-arg-actions.sh`, and `tests/shellcheck-workflow-dialect-consistency.sh`) under the CI runner and they passed; `git diff --check` also passed; environment attempts to call the external Qodo endpoint were blocked by a network proxy (HTTP 403) and the container lacks a `busybox` binary so the explicit `busybox ash` invocation was not available in this runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a91ef9aa8f883299c1c5f3c3a29c4a6)