### PR TITLE
Improve test fixtures: add event-script transactions, make dnsmasq test BusyBox-safe, and extend IPSet fixture

### DIFF
--- a/tests/adguardhome-proc-settings.sh
+++ b/tests/adguardhome-proc-settings.sh
@@ -293,6 +293,20 @@ EOF
 		printf '%s\n' rollback >>"${EVENTS_FILE}"
 		return 0
 	}
+	all_event_scripts_transaction_begin() {
+		all_event_scripts_snapshot "$1" || return 1
+		EVENT_SCRIPTS_ACTIVE_SNAPSHOT="$1"
+	}
+	all_event_scripts_transaction_commit() {
+		[ -n "${EVENT_SCRIPTS_ACTIVE_SNAPSHOT:-}" ] || return 0
+		rm -rf "${EVENT_SCRIPTS_ACTIVE_SNAPSHOT}"
+		EVENT_SCRIPTS_ACTIVE_SNAPSHOT=""
+	}
+	all_event_scripts_transaction_rollback() {
+		[ -n "${EVENT_SCRIPTS_ACTIVE_SNAPSHOT:-}" ] || return 0
+		all_event_scripts_rollback "${EVENT_SCRIPTS_ACTIVE_SNAPSHOT}" || return 1
+		EVENT_SCRIPTS_ACTIVE_SNAPSHOT=""
+	}
 	remove_dnsmasq_event_scripts() { :; }
 	remove_firewall_event_scripts() { :; }
 	remove_init_event_scripts() { :; }

--- a/tests/dnsmasq-lan-mode.sh
+++ b/tests/dnsmasq-lan-mode.sh
@@ -6,7 +6,6 @@ set -u
 SCRIPT_PATH="${1:-AdGuardHome.sh}"
 TEST_ROOT="${TMPDIR:-/tmp}/dnsmasq-lan-mode.$$"
 FUNCTIONS_FILE="${TEST_ROOT}/functions"
-BIN_DIR="${TEST_ROOT}/bin"
 LOG_FILE="${TEST_ROOT}/log"
 IPSET_CALLS_FILE="${TEST_ROOT}/ipset-calls"
 MANAGED_IPSET_FILE="${TEST_ROOT}/managed-ipset"
@@ -30,7 +29,7 @@ trap cleanup 0
 trap 'cleanup; exit 1' HUP INT TERM
 
 [ -f "${SCRIPT_PATH}" ] || fail "script not found: ${SCRIPT_PATH}"
-mkdir -p "${BIN_DIR}" || fail 'could not create test directory'
+mkdir -p "${TEST_ROOT}" || fail 'could not create test directory'
 
 sed -n '/^dnsmasq_delete_matching() {$/,/^interface_ipv4_addr() {$/p' "${SCRIPT_PATH}" | sed '$d' >"${FUNCTIONS_FILE}" ||
 	fail 'could not extract dnsmasq helpers'
@@ -40,26 +39,6 @@ sed -i \
 	-e 's|CONFIG="/etc/dnsmasq.conf"|CONFIG="${DNSMASQ_CONF_FILE}"|' \
 	-e 's|CONFIG="/etc/dnsmasq-${1}.conf"|CONFIG="${DNSMASQ_SDN_CONF_FILE}"|' \
 	"${FUNCTIONS_FILE}" || fail 'could not sandbox dnsmasq config paths'
-
-cat >"${BIN_DIR}/pidof" <<'EOF_PIDOF' || fail 'could not write pidof stub'
-#!/bin/sh
-case "$1" in
-	dnsmasq)
-		[ "${DNSMASQ_RUNNING:-0}" = "1" ] && printf '%s\n' 111
-		;;
-	AdGuardHome)
-		[ "${ADGUARD_RUNNING:-0}" = "1" ] && printf '%s\n' 222
-		;;
-esac
-EOF_PIDOF
-chmod 700 "${BIN_DIR}/pidof" || fail 'could not make pidof stub executable'
-cat >"${BIN_DIR}/umount" <<'EOF_UMOUNT' || fail 'could not write umount stub'
-#!/bin/sh
-printf '%s\n' "$1" >>"${UMOUNT_CALLS_FILE}"
-EOF_UMOUNT
-chmod 700 "${BIN_DIR}/umount" || fail 'could not make umount stub executable'
-PATH="${BIN_DIR}:${PATH}"
-export PATH
 
 # shellcheck disable=SC1090
 . "${FUNCTIONS_FILE}"
@@ -73,7 +52,19 @@ ADGUARD_DNSMASQ_MODE='auto'
 CONFIG_DNSMASQ_MODE="${ADGUARD_DNSMASQ_MODE}"
 RESOLV_CONF_USES_ROM='1'
 RESOLV_CONF_TMP_MOUNT='0'
-export DNSMASQ_RUNNING ADGUARD_RUNNING UMOUNT_CALLS_FILE
+
+# pidof reports fixture process state without relying on PATH interception.
+# BusyBox ash can execute an applet directly instead of a same-named test stub.
+pidof() {
+	case "$1" in
+		dnsmasq)
+			[ "${DNSMASQ_RUNNING:-0}" = "1" ] && printf '%s\n' 111
+			;;
+		AdGuardHome)
+			[ "${ADGUARD_RUNNING:-0}" = "1" ] && printf '%s\n' 222
+			;;
+	esac
+}
 
 # agh_log appends a colon-delimited log entry with a tag, timestamp, and message to the test log file.
 agh_log() {
@@ -107,6 +98,12 @@ resolv_conf_uses_rom() {
 # resolv_conf_is_tmp_mount determines whether resolv.conf is mounted from a temporary filesystem.
 resolv_conf_is_tmp_mount() {
 	[ "${RESOLV_CONF_TMP_MOUNT}" = '1' ]
+}
+
+# umount records cleanup requests without relying on PATH interception. BusyBox
+# ash can execute an applet directly instead of the same-named test stub.
+umount() {
+	printf '%s\n' "$1" >>"${UMOUNT_CALLS_FILE}"
 }
 
 # dns_handoff_is_active determines whether DNS handoff is active.

--- a/tests/ipset-version-gate.sh
+++ b/tests/ipset-version-gate.sh
@@ -7,9 +7,10 @@ SCRIPT_PATH="${1:-AdGuardHome.sh}"
 FUNCTION_FILE="${TMPDIR:-/tmp}/ipset-version-functions.$$"
 BINARY_FILE="${TMPDIR:-/tmp}/AdGuardHome-version-test.$$"
 CALLS_FILE="${TMPDIR:-/tmp}/ipset-version-calls.$$"
+IPSET_FILE="${TMPDIR:-/tmp}/ipset-version-managed.$$"
 
 cleanup() {
-	rm -f "${FUNCTION_FILE}" "${BINARY_FILE}" "${CALLS_FILE}"
+	rm -f "${FUNCTION_FILE}" "${BINARY_FILE}" "${CALLS_FILE}" "${IPSET_FILE}"
 }
 
 fail() {
@@ -47,6 +48,11 @@ adguard_lan_mode() {
 # adguard_ipset_allowed determines whether managed IPSET integration is allowed for the current installation mode.
 adguard_ipset_allowed() {
 	! adguard_lan_mode
+}
+
+# IPSet_Current_File reports that the fixture's managed IPSET file is active.
+IPSet_Current_File() {
+	printf '%s\n' "${IPSET_FILE}"
 }
 
 # IPSet_Disable_Managed records the managed IPSET disable operation and returns its configured status.


### PR DESCRIPTION
### Motivation

- Provide transaction semantics for event-script snapshots in uninstall tests so rollbacks and commits are tracked and cleaned up.  
- Make the `dnsmasq-lan-mode` test robust on BusyBox-based shells by avoiding PATH-replaced applet stubs that may be ignored.  
- Surface the managed IPSET file in the IPSET version-gate test so the fixture can assert which managed file is active.  

### Description

- Add `all_event_scripts_transaction_begin`, `all_event_scripts_transaction_commit`, and `all_event_scripts_transaction_rollback` helpers and the `EVENT_SCRIPTS_ACTIVE_SNAPSHOT` tracking variable in `tests/adguardhome-proc-settings.sh`.  
- Update `tests/dnsmasq-lan-mode.sh` to consistently use `TEST_ROOT` for setup and replace PATH-based `pidof`/`umount` stubs with inline `pidof()` and `umount()` functions that record calls and work correctly under BusyBox ash.  
- Add an `IPSET_FILE` fixture and `IPSet_Current_File()` helper in `tests/ipset-version-gate.sh`, and ensure the fixture file is removed during cleanup.  
- Tidy exports and test sandbox setup to avoid touching system paths and to record operations in test-specific log files.  

### Testing

- Ran the modified uninstall test in `tests/adguardhome-proc-settings.sh` exercising successful and failed restore scenarios, and it completed successfully.  
- Executed `tests/dnsmasq-lan-mode.sh` to validate dnsmasq handoff and topology-aware IPSET refresh behavior under the BusyBox-compatible stubs, and it passed.  
- Ran `tests/ipset-version-gate.sh` to verify IPSET gating and `IPSet_Current_File()` reporting, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a91ef9aa8f883299c1c5f3c3a29c4a6)