### PR TITLE
Serialize dnsmasq IPSet publication transactions

### DIFF
--- a/AdGuardHome.sh
+++ b/AdGuardHome.sh
@@ -14,6 +14,7 @@ MID_SCRIPT="/jffs/addons/AdGuardHome.d/AdGuardHome.sh"
 UPPER_SCRIPT="/opt/etc/init.d/S99AdGuardHome"
 LOWER_SCRIPT="/opt/etc/init.d/rc.func.AdGuardHome"
 IPSET_FILE="/opt/etc/AdGuardHome/ipset.conf"
+IPSET_LOCK_ACTIVE="0"
 IPSET_RUNTIME_DIR="${IPSET_RUNTIME_DIR:-/opt/var/run/AdGuardHome-ipset}"
 IPSET_USER_FILE="/opt/etc/AdGuardHome/ipset.user"
 PROC_SYS_ROOT="${PROC_SYS_ROOT:-/proc/sys}"
@@ -1075,54 +1076,64 @@ dnsmasq_publish_staged_config() (
 		[ "${CONFIG_PUBLISHED:-0}" = "1" ] || rm -f "${CONFIG_STAGE}"
 		exit 1
 	}
+	# dnsmasq_publish_locked snapshots, refreshes, publishes, and compensates while the shared IPSet lock is held.
+	dnsmasq_publish_locked() {
+		if ! dnsmasq_ipset_state_snapshot "${IPSET_SNAPSHOT_DIR}"; then
+			TRANSACTION_ACTIVE="0"
+			rm -f "${CONFIG_STAGE}"
+			return 1
+		fi
+		SNAPSHOT_READY="1"
+		if ! IPSet_Refresh "${CONFIG_STAGE}"; then
+			ROLLBACK_ACTIVE="1"
+			if dnsmasq_ipset_state_restore "${IPSET_SNAPSHOT_DIR}" "${ADGUARD_WAS_RUNNING}"; then
+				rm -rf "${IPSET_SNAPSHOT_DIR}"
+			else
+				agh_log error dnsmasq_params "state=refresh action=restore_ipset result=failed snapshot=${IPSET_SNAPSHOT_DIR}"
+			fi
+			ROLLBACK_ACTIVE="0"
+			if [ "${TRANSACTION_SIGNAL_PENDING}" = "1" ]; then
+				TRANSACTION_SIGNAL_PENDING="0"
+				TRANSACTION_ACTIVE="0"
+				dnsmasq_publish_abort
+			fi
+			TRANSACTION_ACTIVE="0"
+			rm -f "${CONFIG_STAGE}"
+			return 1
+		fi
+		if ! mv "${CONFIG_STAGE}" "${CONFIG_FILE}"; then
+			ROLLBACK_ACTIVE="1"
+			if dnsmasq_ipset_state_restore "${IPSET_SNAPSHOT_DIR}" "${ADGUARD_WAS_RUNNING}"; then
+				rm -rf "${IPSET_SNAPSHOT_DIR}"
+			else
+				agh_log error dnsmasq_params "state=publication action=restore_ipset result=failed snapshot=${IPSET_SNAPSHOT_DIR}"
+			fi
+			ROLLBACK_ACTIVE="0"
+			if [ "${TRANSACTION_SIGNAL_PENDING}" = "1" ]; then
+				TRANSACTION_SIGNAL_PENDING="0"
+				TRANSACTION_ACTIVE="0"
+				dnsmasq_publish_abort
+			fi
+			TRANSACTION_ACTIVE="0"
+			rm -f "${CONFIG_STAGE}"
+			return 1
+		fi
+		CONFIG_PUBLISHED="1"
+		TRANSACTION_ACTIVE="0"
+		rm -rf "${IPSET_SNAPSHOT_DIR}" 2>/dev/null || true
+		return 0
+	}
 	IPSET_LOCK_INTERRUPT_CALLBACK="dnsmasq_publish_abort"
 	trap 'dnsmasq_publish_abort' HUP INT QUIT ABRT TERM TSTP
-	if ! dnsmasq_ipset_state_snapshot "${IPSET_SNAPSHOT_DIR}"; then
-		TRANSACTION_ACTIVE="0"
-		rm -f "${CONFIG_STAGE}"
-		return 1
-	fi
-	SNAPSHOT_READY="1"
-	if ! IPSet_Refresh "${CONFIG_STAGE}"; then
-		ROLLBACK_ACTIVE="1"
-		if dnsmasq_ipset_state_restore "${IPSET_SNAPSHOT_DIR}" "${ADGUARD_WAS_RUNNING}"; then
-			rm -rf "${IPSET_SNAPSHOT_DIR}"
-		else
-			agh_log error dnsmasq_params "state=refresh action=restore_ipset result=failed snapshot=${IPSET_SNAPSHOT_DIR}"
-		fi
-		ROLLBACK_ACTIVE="0"
-		if [ "${TRANSACTION_SIGNAL_PENDING}" = "1" ]; then
-			TRANSACTION_SIGNAL_PENDING="0"
-			TRANSACTION_ACTIVE="0"
-			dnsmasq_publish_abort
-		fi
-		TRANSACTION_ACTIVE="0"
-		rm -f "${CONFIG_STAGE}"
-		return 1
-	fi
-	if ! mv "${CONFIG_STAGE}" "${CONFIG_FILE}"; then
-		ROLLBACK_ACTIVE="1"
-		if dnsmasq_ipset_state_restore "${IPSET_SNAPSHOT_DIR}" "${ADGUARD_WAS_RUNNING}"; then
-			rm -rf "${IPSET_SNAPSHOT_DIR}"
-		else
-			agh_log error dnsmasq_params "state=publication action=restore_ipset result=failed snapshot=${IPSET_SNAPSHOT_DIR}"
-		fi
-		ROLLBACK_ACTIVE="0"
-		if [ "${TRANSACTION_SIGNAL_PENDING}" = "1" ]; then
-			TRANSACTION_SIGNAL_PENDING="0"
-			TRANSACTION_ACTIVE="0"
-			dnsmasq_publish_abort
-		fi
-		TRANSACTION_ACTIVE="0"
-		rm -f "${CONFIG_STAGE}"
-		return 1
-	fi
-	CONFIG_PUBLISHED="1"
-	TRANSACTION_ACTIVE="0"
+	IPSet_Lock dnsmasq_publish_locked
+	STATUS="$?"
 	IPSET_LOCK_INTERRUPT_CALLBACK=""
 	trap - HUP INT QUIT ABRT TERM TSTP
-	rm -rf "${IPSET_SNAPSHOT_DIR}" 2>/dev/null || true
-	return 0
+	if [ "${STATUS}" -ne 0 ] && [ "${SNAPSHOT_READY}" = "0" ]; then
+		TRANSACTION_ACTIVE="0"
+		rm -f "${CONFIG_STAGE}"
+	fi
+	return "${STATUS}"
 )
 
 # dnsmasq_params configures dnsmasq for the LAN or specified SDN interface, including DNS routing, reverse zones, and optional IPSet refresh.
@@ -3269,7 +3280,7 @@ IPSet_Lock_Interrupt_Cleanup() {
 	fi
 }
 
-# IPSet_Lock_Interrupt_Propagate invokes an outer transaction's signal cleanup after releasing the IPSET lock.
+# IPSet_Lock_Interrupt_Propagate invokes an outer transaction's signal cleanup while the IPSET lock remains held.
 IPSet_Lock_Interrupt_Propagate() {
 	[ -n "${IPSET_LOCK_INTERRUPT_CALLBACK:-}" ] || return 0
 	"${IPSET_LOCK_INTERRUPT_CALLBACK}"
@@ -3304,6 +3315,10 @@ IPSet_Start_While_Locked() {
 
 IPSet_Lock() {
 	local STATUS
+	if [ "${IPSET_LOCK_ACTIVE:-0}" = "1" ]; then
+		"$@"
+		return "$?"
+	fi
 	IPSet_Runtime_Prepare || return 1
 	# Prefer flock on firmware that supports descriptor locking.  The private,
 	# ownership-validated mkdir lock remains the fallback for older firmware.
@@ -3335,10 +3350,12 @@ IPSet_Lock_Flock() {
 		return 1
 	fi
 	# Restore a stopped service while this lock is still held; only then release it.
-	trap 'if [ "${ROLLBACK_ACTIVE:-0}" = "1" ]; then TRANSACTION_SIGNAL_PENDING="1"; else IPSet_Lock_Interrupt_Cleanup; IPSet_Lock_Flock_Cleanup; IPSet_Dnsmasq_Restart_After_Unlock; IPSet_Restore_Traps "${SAVED_TRAPS}"; IPSet_Lock_Interrupt_Propagate; exit 1; fi' HUP INT QUIT ABRT TERM TSTP
-	trap 'STATUS="$?"; IPSet_Lock_Flock_Cleanup; IPSet_Restore_Traps "${SAVED_TRAPS}"; exit "${STATUS}"' EXIT
+	trap 'if [ "${ROLLBACK_ACTIVE:-0}" = "1" ]; then TRANSACTION_SIGNAL_PENDING="1"; else IPSet_Lock_Interrupt_Cleanup; IPSet_Lock_Interrupt_Propagate; IPSet_Lock_Flock_Cleanup; IPSet_Dnsmasq_Restart_After_Unlock; IPSet_Restore_Traps "${SAVED_TRAPS}"; exit 1; fi' HUP INT QUIT ABRT TERM TSTP
+	trap 'STATUS="$?"; IPSet_Lock_Flock_Cleanup; IPSet_Dnsmasq_Restart_After_Unlock; IPSet_Restore_Traps "${SAVED_TRAPS}"; exit "${STATUS}"' EXIT
+	IPSET_LOCK_ACTIVE="1"
 	"$@"
 	STATUS="$?"
+	IPSET_LOCK_ACTIVE="0"
 	IPSet_Lock_Flock_Cleanup
 	IPSet_Restore_Traps "${SAVED_TRAPS}"
 	return "${STATUS}"
@@ -3402,10 +3419,12 @@ IPSet_Lock_Mkdir() {
 	done <"${TRAP_STATE_FILE}"
 	rm -f "${TRAP_STATE_FILE}"
 	# Keep the fallback lock through restoration for the same lifecycle guarantee.
-	trap 'if [ "${ROLLBACK_ACTIVE:-0}" = "1" ]; then TRANSACTION_SIGNAL_PENDING="1"; else IPSet_Lock_Interrupt_Cleanup; IPSet_Lock_Mkdir_Cleanup "${LOCK_DIR}"; IPSet_Dnsmasq_Restart_After_Unlock; IPSet_Restore_Traps "${SAVED_TRAPS}"; IPSet_Lock_Interrupt_Propagate; exit 1; fi' HUP INT QUIT ABRT TERM TSTP
-	trap 'STATUS="$?"; IPSet_Lock_Mkdir_Cleanup "${LOCK_DIR}"; IPSet_Restore_Traps "${SAVED_TRAPS}"; exit "${STATUS}"' EXIT
+	trap 'if [ "${ROLLBACK_ACTIVE:-0}" = "1" ]; then TRANSACTION_SIGNAL_PENDING="1"; else IPSet_Lock_Interrupt_Cleanup; IPSet_Lock_Interrupt_Propagate; IPSet_Lock_Mkdir_Cleanup "${LOCK_DIR}"; IPSet_Dnsmasq_Restart_After_Unlock; IPSet_Restore_Traps "${SAVED_TRAPS}"; exit 1; fi' HUP INT QUIT ABRT TERM TSTP
+	trap 'STATUS="$?"; IPSet_Lock_Mkdir_Cleanup "${LOCK_DIR}"; IPSet_Dnsmasq_Restart_After_Unlock; IPSet_Restore_Traps "${SAVED_TRAPS}"; exit "${STATUS}"' EXIT
+	IPSET_LOCK_ACTIVE="1"
 	"$@"
 	STATUS="$?"
+	IPSET_LOCK_ACTIVE="0"
 	IPSet_Lock_Mkdir_Cleanup "${LOCK_DIR}"
 	IPSet_Restore_Traps "${SAVED_TRAPS}"
 	return "${STATUS}"

--- a/tests/dnsmasq-lan-mode.sh
+++ b/tests/dnsmasq-lan-mode.sh
@@ -8,6 +8,7 @@ TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/dnsmasq-lan-mode.XXXXXX")" || {
 	printf '%s\n' 'FAIL: could not create exclusive test directory' >&2
 	exit 1
 }
+IPSET_TEST_LOCK_DIR="${TEST_ROOT}/ipset-transaction-lock"
 FUNCTIONS_FILE="${TEST_ROOT}/functions"
 LOG_FILE="${TEST_ROOT}/log"
 IPSET_CALLS_FILE="${TEST_ROOT}/ipset-calls"
@@ -181,6 +182,8 @@ sdn_bridge_for_index() {
 
 # IPSet_Refresh records a refresh request, updates refresh state, and removes managed IPSET state when the topology does not support it.
 IPSet_Refresh() {
+	[ "${IPSET_LOCK_ACTIVE:-0}" = "1" ] || fail 'IPSET refresh ran outside the transaction lock'
+	[ -d "${IPSET_SNAPSHOT_DIR:-}" ] || fail 'IPSET refresh ran before the transaction snapshot'
 	printf '%s\n' "$1" >>"${IPSET_CALLS_FILE}"
 	if [ "${IPSET_REFRESH_FAIL:-0}" = "1" ]; then
 		printf '%s\n' refreshed >"${IPSET_FILE}"
@@ -207,6 +210,36 @@ IPSet_Refresh() {
 	return 0
 }
 
+# IPSet_Lock marks the fixture transaction as locked while running its callback.
+IPSet_Lock() {
+	local cleanup_status lock_attempts status
+	if [ "${IPSET_LOCK_ACTIVE:-0}" = "1" ]; then
+		"$@"
+		return "$?"
+	fi
+	lock_attempts="0"
+	while ! mkdir "${IPSET_TEST_LOCK_DIR}" 2>/dev/null; do
+		[ -z "${IPSET_LOCK_WAIT_MARKER:-}" ] || : >"${IPSET_LOCK_WAIT_MARKER}" || return 1
+		lock_attempts="$((lock_attempts + 1))"
+		if [ "${lock_attempts}" -ge 10 ]; then
+			printf '%s\n' 'FAIL: fixture transaction lock was not released' >&2
+			return 1
+		fi
+		sleep 1
+	done
+	trap 'rmdir "${IPSET_TEST_LOCK_DIR}" 2>/dev/null' EXIT
+	IPSET_LOCK_ACTIVE="1"
+	"$@"
+	status="$?"
+	IPSET_LOCK_ACTIVE="0"
+	cleanup_status="0"
+	rmdir "${IPSET_TEST_LOCK_DIR}" || cleanup_status="1"
+	trap - EXIT
+	[ "${status}" -eq 0 ] || return "${status}"
+	[ "${cleanup_status}" -eq 0 ] || return "${cleanup_status}"
+	return "${status}"
+}
+
 # lower_script records successful service reloads required after IPSET snapshot restoration.
 lower_script() { printf '%s\n' "$*" >>"${IPSET_CALLS_FILE}"; }
 
@@ -218,6 +251,9 @@ IPSet_Lock_Interrupt_Propagate() {
 
 # mv injects configured failures for dnsmasq publication or IPSET snapshot restoration moves, then delegates other operations to the system command.
 mv() {
+	if [ "${TRANSACTION_ACTIVE:-0}" = "1" ]; then
+		[ "${IPSET_LOCK_ACTIVE:-0}" = "1" ] || fail 'dnsmasq publication or compensation ran outside the transaction lock'
+	fi
 	if [ "${RESTORE_FAIL:-0}" = "1" ]; then
 		case "${1:-}" in
 			"${IPSET_FILE}.dnsmasq-restore."*) return 1 ;;
@@ -269,6 +305,8 @@ reset_case() {
 	RESTORE_FAIL='0'
 	MOUNT_FAIL='0'
 	CONFIG_LOCAL='NO'
+	[ -z "${SECOND_STARTED:-}" ] || rm -f "${SECOND_STARTED}"
+	[ -z "${SECOND_WAITING:-}" ] || rm -f "${SECOND_WAITING}"
 }
 
 # assert_no_ipset_refresh verifies that no IPSET refresh calls were recorded for the test case.
@@ -637,6 +675,57 @@ ADGUARD_RUNNING='1'
 dnsmasq_ipset_state_restore "${STOPPED_SNAPSHOT}" 0 || fail 'stopped-service state restoration failed'
 grep -q '^restart$' "${IPSET_CALLS_FILE}" || fail 'stopped-service rollback did not reload a newly appearing process'
 rm -rf "${STOPPED_SNAPSHOT}" || fail 'could not clear stopped-service snapshot'
+
+# Overlapping base and SDN callbacks must serialize snapshot, refresh,
+# publication, and compensation as one transaction.
+reset_case
+FIRST_MARKER="${TEST_ROOT}/first-refresh-active"
+FIRST_RELEASE="${TEST_ROOT}/first-refresh-release"
+SECOND_MARKER="${TEST_ROOT}/second-refresh-active"
+SECOND_STARTED="${TEST_ROOT}/second-transaction-started"
+SECOND_WAITING="${TEST_ROOT}/second-transaction-waiting"
+FIRST_STAGE="${DNSMASQ_CONF_FILE}.adguard.first"
+SECOND_STAGE="${DNSMASQ_SDN_CONF_FILE}.adguard.second"
+FIRST_SNAPSHOT="${TEST_ROOT}/.AdGuardHome.dnsmasq-ipset.first"
+SECOND_SNAPSHOT="${TEST_ROOT}/.AdGuardHome.dnsmasq-ipset.second"
+printf '%s\n' '# first staged config' >"${FIRST_STAGE}" || fail 'could not create first concurrent stage'
+printf '%s\n' '# second staged config' >"${SECOND_STAGE}" || fail 'could not create second concurrent stage'
+printf '%s\n' 'original ipset' >"${IPSET_FILE}" || fail 'could not create concurrent IPSET fixture'
+(
+	IPSet_Refresh() {
+		printf '%s\n' first >"${IPSET_FILE}"
+		printf '%s\n' first >"${YAML_FILE}"
+		: >"${FIRST_MARKER}"
+		wait_for_release "${FIRST_RELEASE}"
+	}
+	MV_PUBLISH_FAIL='1'
+	dnsmasq_publish_staged_config "${DNSMASQ_CONF_FILE}" "${FIRST_STAGE}" "${FIRST_SNAPSHOT}"
+) &
+first_pid="$!"
+wait_for_file "${FIRST_MARKER}" || fail 'first concurrent transaction did not enter refresh'
+(
+	IPSet_Refresh() {
+		: >"${SECOND_MARKER}"
+		printf '%s\n' second >"${IPSET_FILE}"
+		printf '%s\n' second >"${YAML_FILE}"
+	}
+	MV_PUBLISH_FAIL='0'
+	IPSET_LOCK_WAIT_MARKER="${SECOND_WAITING}"
+	: >"${SECOND_STARTED}"
+	dnsmasq_publish_staged_config "${DNSMASQ_SDN_CONF_FILE}" "${SECOND_STAGE}" "${SECOND_SNAPSHOT}"
+) &
+second_pid="$!"
+wait_for_file "${SECOND_STARTED}" || fail 'second concurrent transaction did not start'
+wait_for_file "${SECOND_WAITING}" || fail 'second concurrent transaction did not wait for the first lock holder'
+[ ! -e "${SECOND_MARKER}" ] || fail 'second callback refreshed state before the first transaction completed'
+: >"${FIRST_RELEASE}" || fail 'could not release first concurrent transaction'
+if wait "${first_pid}"; then
+	fail 'first concurrent publication failure unexpectedly succeeded'
+fi
+wait "${second_pid}" || fail 'second concurrent transaction failed after waiting for the lock'
+grep -qx second "${IPSET_FILE}" || fail 'first compensation overwrote the second callback IPSET state'
+grep -qx second "${YAML_FILE}" || fail 'first compensation overwrote the second callback YAML state'
+grep -qx '# second staged config' "${DNSMASQ_SDN_CONF_FILE}" || fail 'second callback did not publish its dnsmasq state'
 
 # A nested IPSET lock signal handler must propagate to the outer dnsmasq
 # transaction so partially refreshed state is restored.

--- a/tests/ipset-lock-security.sh
+++ b/tests/ipset-lock-security.sh
@@ -38,11 +38,11 @@ fi
 if grep -Eq 'IPSET_LOCK_ROOT|/tmp/AdGuardHome-ipset' "${SCRIPT_PATH}"; then
 	fail 'legacy IPSET lock paths remain in the installer'
 fi
-if ! grep -Fq 'IPSet_Lock_Interrupt_Cleanup; IPSet_Lock_Flock_Cleanup; IPSet_Dnsmasq_Restart_After_Unlock; IPSet_Restore_Traps' "${SCRIPT_PATH}"; then
-	fail 'flock interrupt cleanup does not restore AdGuardHome before releasing the lock'
+if ! grep -Fq 'IPSet_Lock_Interrupt_Cleanup; IPSet_Lock_Interrupt_Propagate; IPSet_Lock_Flock_Cleanup; IPSet_Dnsmasq_Restart_After_Unlock; IPSet_Restore_Traps' "${SCRIPT_PATH}"; then
+	fail 'flock interrupt cleanup does not compensate the outer transaction before releasing the lock'
 fi
-if ! grep -Fq 'IPSet_Lock_Interrupt_Cleanup; IPSet_Lock_Mkdir_Cleanup "${LOCK_DIR}"; IPSet_Dnsmasq_Restart_After_Unlock; IPSet_Restore_Traps' "${SCRIPT_PATH}"; then
-	fail 'fallback interrupt cleanup does not restore AdGuardHome before releasing the lock'
+if ! grep -Fq 'IPSet_Lock_Interrupt_Cleanup; IPSet_Lock_Interrupt_Propagate; IPSet_Lock_Mkdir_Cleanup "${LOCK_DIR}"; IPSet_Dnsmasq_Restart_After_Unlock; IPSet_Restore_Traps' "${SCRIPT_PATH}"; then
+	fail 'fallback interrupt cleanup does not compensate the outer transaction before releasing the lock'
 fi
 grep -Fq 'IPSet_Restore_Traps "${SAVED_TRAPS}"' "${SCRIPT_PATH}" ||
 	fail 'nested IPSET lock cleanup does not restore saved traps'
@@ -146,6 +146,16 @@ IPSet_Lock_Interrupt_Cleanup() {
 }
 
 outer_transaction_cleanup() {
+	case "${LOCK_MODE}" in
+		flock)
+			if (exec 9>"${IPSET_RUNTIME_DIR}/flock" && flock -n 9); then
+				exit 1
+			fi
+			;;
+		mkdir)
+			[ -d "${IPSET_RUNTIME_DIR}/mkdir" ] || exit 1
+			;;
+	esac
 	printf '%s\n' propagated >"${TEST_ROOT}/${LOCK_MODE}-interrupt-propagated"
 }
 IPSET_LOCK_INTERRUPT_CALLBACK='outer_transaction_cleanup'
@@ -234,6 +244,11 @@ lock_action() {
 	printf '%s\n' called >"${TEST_ROOT}/called"
 }
 
+# nested_lock_action verifies a lock callback can reuse the lock without blocking.
+nested_lock_action() {
+	IPSet_Lock lock_action
+}
+
 # lock_dnsmasq_action marks a dnsmasq restart as pending.
 lock_dnsmasq_action() {
 	IPSET_DNSMASQ_RESTART_PENDING="1"
@@ -298,6 +313,9 @@ USE_FLOCK=0
 IPSET_RUNTIME_DIR="${TEST_ROOT}/runtime"
 IPSet_Lock lock_action || fail 'could not acquire fallback lock in private runtime directory'
 [ "$(cat "${TEST_ROOT}/called")" = called ] || fail 'locked action did not run'
+rm -f "${TEST_ROOT}/called"
+IPSet_Lock nested_lock_action || fail 'nested IPSET lock reuse failed'
+[ "$(cat "${TEST_ROOT}/called")" = called ] || fail 'nested locked action did not run'
 [ "$(IPSet_Directory_Metadata "${IPSET_RUNTIME_DIR}")" = "$(IPSet_Current_UID) rwx------" ] || fail 'runtime directory is not mode 700'
 [ ! -e "${IPSET_RUNTIME_DIR}/mkdir" ] || fail 'fallback lock directory was not cleaned up'
 rm -f "${TEST_ROOT}/dnsmasq-restarted"


### PR DESCRIPTION
Hold the shared IPSet lock across dnsmasq snapshot, refresh, publication, and rollback to prevent concurrent compensation from overwriting newer state. Support nested lock reuse, propagate interrupt cleanup before unlocking, and expand regression coverage for concurrency, signals, and nested locks.

Validation: git diff --check passed; runtime tests were not run.

[View coding task](https://app.coderabbit.ai/code/tasks/e230c02f-4580-4aec-aace-3c718ce3878a?source=coding_agent_github_pr_description)