### PR TITLE
tests: initialize YAML_FILE and YAML_ORI in timezone regression fixture

### DIFF
--- a/tests/installer-timezone-failure.sh
+++ b/tests/installer-timezone-failure.sh
@@ -53,6 +53,8 @@ chmod 755 "${TMP_ROOT}/target/AdGuardHome" || fail 'could not create test AdGuar
 	AGH_FILE="${TMP_ROOT}/target/AdGuardHome"
 	BASE_DIR="${TMP_ROOT}/base"
 	CONF_FILE="${TMP_ROOT}/target/.config"
+	YAML_FILE="${TMP_ROOT}/AdGuardHome.yaml"
+	YAML_ORI="${TMP_ROOT}/target/.AdGuardHome.yaml.ori"
 	RURL='https://example.invalid'
 	SCRIPT_LOC="${TMP_ROOT}/missing-installer"
 	TARG_DIR="${TMP_ROOT}/target"


### PR DESCRIPTION
### Motivation

- The timezone regression test was failing under `set -u` because `YAML_FILE` (and its companion `YAML_ORI`) were referenced by extracted installer helpers but not defined in the test subshell, causing an undefined-variable failure. 

### Description

- Define `YAML_FILE="${TMP_ROOT}/AdGuardHome.yaml"` and `YAML_ORI="${TMP_ROOT}/target/.AdGuardHome.yaml.ori"` in the subshell variable block of `tests/installer-timezone-failure.sh` so extracted installer functions have the expected global paths.

### Testing

- Ran `sh tests/installer-timezone-failure.sh installer` which reported `PASS: timezone setup failure aborts installation before configuration and startup` (success). 
- Ran `sh -n tests/installer-timezone-failure.sh` for a shell syntax check which reported no errors (success), and `git diff --check` which reported no whitespace/quote issues (success). 
- Note: `busybox ash -n` and `shellcheck -s sh` were attempted but the validation environment tools were unavailable (reported as unavailable rather than failing the patch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a96a4e1223c8329a101632708bfa15c)