### PR TITLE
Fix installer rollback/recovery test fixtures for timezone and install-mode regressions

### DIFF
--- a/tests/installer-dns-environment-failure.sh
+++ b/tests/installer-dns-environment-failure.sh
@@ -154,6 +154,13 @@ sleep() {
 }
 # monotonic_seconds outputs the simulated monotonic timestamp and fails on the configured call number when MONOTONIC_FAIL_AT is set.
 monotonic_seconds() {
+	if [ "${DNS_TEST_YIELD:-0}" = 1 ]; then
+		if [ -x /bin/usleep ]; then
+			/bin/usleep 1000
+		else
+			/bin/sleep 0
+		fi
+	fi
 	if [ "${MONOTONIC_FAIL_AT:-0}" != 0 ]; then
 		MONOTONIC_CALLS="$(cat "${TEST_ROOT}/monotonic-calls" 2>/dev/null || printf 0)"
 		MONOTONIC_CALLS="$((MONOTONIC_CALLS + 1))"
@@ -1500,9 +1507,10 @@ nvram_transaction_set dnspriv_enable 0 || fail 'DNS restore cleanup transaction 
 nvram_transaction_apply restart_dnsmasq 1 || fail 'DNS restore cleanup transaction apply failed'
 _DNS_NVRAM_SAVED=1
 FAIL_SNAPSHOT_REMOVE=1
-# Leave enough simulated readiness time for the background lookup to finish on
-# loaded CI hosts; this case exercises snapshot cleanup, not timeout handling.
+# Yield while polling the background lookup so loaded CI hosts can schedule the
+# fixture child; this case exercises snapshot cleanup, not timeout handling.
 DNS_ENV_RECOVERY_TIMEOUT=10
+DNS_TEST_YIELD=1
 check_dns_environment 1 || fail 'completed DNS restore failed because best-effort snapshot cleanup was interrupted'
 [ "${_DNS_NVRAM_SAVED}" = 0 ] || fail 'completed DNS restore retained the saved-state marker'
 [ -d "${NVRAM_TRANSACTION_DIR}" ] || fail 'DNS restore cleanup injection did not retain the inert snapshot'

--- a/tests/installer-install-mode-detection.sh
+++ b/tests/installer-install-mode-detection.sh
@@ -197,14 +197,6 @@ extract_function adguard_restart_after_install_abort "${TMP_ROOT}/install-abort-
 	fail 'could not extract install-abort restart helper'
 extract_function adguard_recover_after_event_hook_abort "${TMP_ROOT}/event-hook-recovery" ||
 	fail 'could not extract event-hook recovery helper'
-grep -Fq 'if ! finalize_pending_mode_migration; then' "${TMP_ROOT}/install-path" ||
-	fail 'install orchestration must propagate mode migration finalization failures'
-awk '
-	/if ! finalize_pending_mode_migration; then/ { failure = 1; next }
-	failure && /adguard_recover_after_event_hook_abort "\$\{RESTART_AFTER_ABORT\}" 1/ { recovered = 1; next }
-	failure && /end_op_message 1 "\$1"/ { exit(recovered ? 0 : 1) }
-	END { if (!failure || !recovered) exit 1 }
-' "${TMP_ROOT}/install-path" || fail 'finalization failure does not recover the previous installation'
 grep -Fq 'return "${MIGRATE_STATUS}"' "${TMP_ROOT}/install-path" ||
 	fail 'install orchestration does not preserve migration rollback failure status'
 awk '
@@ -213,42 +205,8 @@ awk '
 	update_call { exit($0 ~ /^[[:space:]]*return \$\?[[:space:]]*$/ ? 0 : 1) }
 	END { if (!update_call) exit 1 }
 ' "${TMP_ROOT}/install-path" || fail 'recursive package update does not immediately propagate migration failure status'
-
-awk '
-	/if ! agh_complete_startup; then/ { readiness = NR }
-	/if ! finalize_pending_mode_migration; then/ { finalize = NR }
-	END { exit(readiness && finalize > readiness ? 0 : 1) }
-' "${TMP_ROOT}/install-path" || fail 'mode migration is finalized before post-install readiness succeeds'
-awk '
-	/if \[ "\$\{2:-0\}" = "1" \]; then/ { readiness = 1; next }
-	readiness && /agh_stop/ { stopped = NR; next }
-	readiness && /adguard_restart_after_install_abort "\$1"/ {
-		restarted = NR
-		exit(stopped && stopped < restarted ? 0 : 1)
-	}
-	END { if (!stopped || !restarted) exit 1 }
-' "${TMP_ROOT}/event-hook-recovery" || fail 'readiness rollback does not stop the migrated process before restoring the previous service state'
-awk '
-	/if ! set_timezone; then/ { failure = "timezone" }
-	/if ! setup_AdGuardHome "" "\$\{1:-install\}"; then/ { failure = "setup" }
-	/if ! agh_complete_startup; then/ { failure = "readiness" }
-	failure && /adguard_recover_after_event_hook_abort/ { rollback[failure] = 1 }
-	failure && /end_op_message 1/ {
-		if (!rollback[failure]) exit 1
-		failure = ""
-	}
-	END { exit(rollback["timezone"] && rollback["setup"] && rollback["readiness"] ? 0 : 1) }
-' "${TMP_ROOT}/install-path" || fail 'post-migration failure paths can re-enter the menu before rollback'
-awk '
-	/if rollback_pending_mode_migration; then/ { rollback = 1; next }
-	rollback && /else/ { failure = 1; next }
-	failure && /MODE_ROLLBACK_STATUS=1/ { recorded = 1; next }
-	recorded && /adguard_restart_after_install_abort "\$1"/ { restarted = 1; exit }
-	END { exit(restarted ? 0 : 1) }
-' "${TMP_ROOT}/event-hook-recovery" || fail 'migration rollback failure blocks the previous installation restart'
-# run_legacy_cleanup_failure executes one injected legacy-cleanup failure and
-# run_legacy_cleanup_failure verifies aggregate rollback, mode rollback, service and monitor recovery, and failure status for legacy cleanup errors.
-run_legacy_cleanup_failure() (
+# run_install_failure executes an injected cleanup or post-migration failure and verifies observable recovery behavior.
+run_install_failure() (
 	FAILURE_CASE="$1"
 	CALLS_FILE="${TMP_ROOT}/legacy-cleanup-${FAILURE_CASE}"
 	BASE_DIR="${TMP_ROOT}/legacy-base-${FAILURE_CASE}"
@@ -333,15 +291,22 @@ EOF
 	# all_event_scripts_transaction_begin records the start of an event-script transaction.
 	all_event_scripts_transaction_begin() { printf '%s\n' 'transaction:begin' >>"${CALLS_FILE}"; }
 	# all_event_scripts_transaction_detach_after_mode_rollback detaches a newer aggregate snapshot after restoring the prior mode.
-	all_event_scripts_transaction_detach_after_mode_rollback() { :; }
+	all_event_scripts_transaction_detach_after_mode_rollback() { printf '%s\n' 'transaction:detach' >>"${CALLS_FILE}"; }
 	# all_event_scripts_transaction_rollback records an event-script transaction rollback.
 	all_event_scripts_transaction_rollback() { printf '%s\n' 'transaction:rollback' >>"${CALLS_FILE}"; }
+	# all_event_scripts_transaction_commit records publication of the aggregate event-script transaction.
+	all_event_scripts_transaction_commit() { printf '%s\n' 'transaction:commit' >>"${CALLS_FILE}"; }
 	# nvram_transaction_lock_owned reports that these hook-failure fixtures have no active NVRAM transaction.
 	nvram_transaction_lock_owned() { return 1; }
 	# install_wan_event_scripts reports successful WAN event-script synchronization.
 	install_wan_event_scripts() { return 0; }
-	# rollback_pending_mode_migration records a pending mode migration rollback.
-	rollback_pending_mode_migration() { printf '%s\n' 'mode:rollback' >>"${CALLS_FILE}"; }
+	# rollback_pending_mode_migration records rollback and retains ownership only for the injected rollback failure.
+	rollback_pending_mode_migration() {
+		printf '%s\n' 'mode:rollback' >>"${CALLS_FILE}"
+		[ "${FAILURE_CASE}" != "rollback" ] || return 1
+		MODE_MIGRATION_YAML_FILE_BACKUP=""
+		return 0
+	}
 	# cleanup_legacy_firewall reports whether the legacy firewall cleanup failure case is active.
 	cleanup_legacy_firewall() {
 		[ "${FAILURE_CASE}" != "firewall" ]
@@ -383,14 +348,44 @@ EOF
 	rollback_result_write() { printf '%s\n' "rollback-result:$*" >>"${CALLS_FILE}"; }
 	# rollback_result_notice performs no operation.
 	rollback_result_notice() { :; }
+	# set_timezone injects the timezone failure or records successful timezone setup.
+	set_timezone() {
+		printf '%s\n' 'timezone' >>"${CALLS_FILE}"
+		[ "${FAILURE_CASE}" != "timezone" ] && [ "${FAILURE_CASE}" != "rollback" ]
+	}
+	# setup_AdGuardHome injects the first-run setup failure when requested.
+	setup_AdGuardHome() {
+		printf '%s\n' 'setup' >>"${CALLS_FILE}"
+		[ "${FAILURE_CASE}" != "setup" ]
+	}
+	# agh_complete_startup injects readiness failure after recording the check.
+	agh_complete_startup() {
+		printf '%s\n' 'readiness' >>"${CALLS_FILE}"
+		[ "${FAILURE_CASE}" != "readiness" ]
+	}
+	# agh_stop records removal of the newly started process before service restoration.
+	agh_stop() { printf '%s\n' 'service:stopped' >>"${CALLS_FILE}"; }
+	# finalize_dns_environment records finalization and injects its failure when requested.
+	finalize_dns_environment() {
+		printf '%s\n' 'dns:finalize' >>"${CALLS_FILE}"
+		[ "${FAILURE_CASE}" != "finalization" ]
+	}
+	# finalize_pending_mode_migration records successful post-readiness migration finalization.
+	finalize_pending_mode_migration() { printf '%s\n' 'mode:finalize' >>"${CALLS_FILE}"; }
 	# end_op_message records the operation status in the calls log.
 	end_op_message() { printf '%s\n' "end-status:$1" >>"${CALLS_FILE}"; }
-	if inst_AdGuardHome update release; then
-		fail "${FAILURE_CASE}: cleanup failure returned success"
+	install_action=update
+	case "${FAILURE_CASE}" in
+		timezone | setup | readiness | rollback) install_action=install ;;
+	esac
+	if inst_AdGuardHome "${install_action}" release; then
+		fail "${FAILURE_CASE}: injected installation failure returned success"
 	else
 		cleanup_status=$?
 	fi
-	[ "${cleanup_status}" -eq 1 ] || fail "${FAILURE_CASE}: unexpected cleanup exit status ${cleanup_status}"
+	expected_status=1
+	[ "${FAILURE_CASE}" != "rollback" ] || expected_status=2
+	[ "${cleanup_status}" -eq "${expected_status}" ] || fail "${FAILURE_CASE}: unexpected cleanup exit status ${cleanup_status}"
 	grep -qx 'transaction:begin' "${CALLS_FILE}" || fail "${FAILURE_CASE}: transaction did not begin"
 	grep -qx 'transaction:rollback' "${CALLS_FILE}" || fail "${FAILURE_CASE}: aggregate rollback was not attempted"
 	grep -qx 'mode:rollback' "${CALLS_FILE}" || fail "${FAILURE_CASE}: mode rollback was not attempted"
@@ -398,11 +393,59 @@ EOF
 	grep -qx 'monitor:restarted' "${CALLS_FILE}" || fail "${FAILURE_CASE}: monitor recovery was not attempted"
 	grep -q '^rollback-result:install-abort rollback complete ' "${CALLS_FILE}" || fail "${FAILURE_CASE}: successful rollback result was not recorded"
 	grep -qx 'end-status:1' "${CALLS_FILE}" || fail "${FAILURE_CASE}: failure completion status was not reported"
+	rollback_line="$(grep -n '^transaction:rollback$' "${CALLS_FILE}" | head -n 1 | cut -d: -f1)"
+	mode_line="$(grep -n '^mode:rollback$' "${CALLS_FILE}" | head -n 1 | cut -d: -f1)"
+	restart_line="$(grep -n '^service:restarted$' "${CALLS_FILE}" | head -n 1 | cut -d: -f1)"
+	end_line="$(grep -n '^end-status:1$' "${CALLS_FILE}" | head -n 1 | cut -d: -f1)"
+	[ "${rollback_line}" -lt "${mode_line}" ] && [ "${mode_line}" -lt "${restart_line}" ] && [ "${restart_line}" -lt "${end_line}" ] ||
+		fail "${FAILURE_CASE}: rollback and service recovery calls occurred out of order"
+	case "${FAILURE_CASE}" in
+		finalization)
+			grep -qx 'dns:finalize' "${CALLS_FILE}" || fail 'finalization: injected finalizer was not reached'
+			;;
+		readiness)
+			grep -qx 'readiness' "${CALLS_FILE}" || fail 'readiness: injected readiness check was not reached'
+			if grep -q '^dns:finalize$' "${CALLS_FILE}"; then
+				fail 'readiness: DNS finalization ran after readiness failed'
+			fi
+			;;
+		timezone)
+			grep -qx 'timezone' "${CALLS_FILE}" || fail 'timezone: injected timezone setup was not reached'
+			if grep -q '^setup$' "${CALLS_FILE}"; then
+				fail 'timezone: first-run setup ran after timezone setup failed'
+			fi
+			;;
+		setup)
+			grep -qx 'setup' "${CALLS_FILE}" || fail 'setup: injected first-run setup was not reached'
+			if grep -q '^readiness$' "${CALLS_FILE}"; then
+				fail 'setup: readiness ran after first-run setup failed'
+			fi
+			;;
+	esac
+	case "${FAILURE_CASE}" in
+		finalization | readiness)
+			stop_line="$(grep -n '^service:stopped$' "${CALLS_FILE}" | cut -d: -f1)"
+			[ -n "${stop_line}" ] && [ "${stop_line}" -lt "${restart_line}" ] ||
+				fail "${FAILURE_CASE}: replacement service was not stopped before previous service recovery"
+			;;
+	esac
+	case "${FAILURE_CASE}" in
+		firewall | dnsmasq | init-start | services-stop | finalization | timezone | setup | readiness)
+			[ -z "${MODE_MIGRATION_YAML_FILE_BACKUP}" ] || fail "${FAILURE_CASE}: successful rollback retained migration ownership"
+			;;
+		rollback)
+			[ -n "${MODE_MIGRATION_YAML_FILE_BACKUP}" ] || fail 'rollback: failed rollback discarded migration ownership'
+			;;
+	esac
 )
 
 for legacy_cleanup_failure in firewall dnsmasq init-start services-stop; do
-	run_legacy_cleanup_failure "${legacy_cleanup_failure}" ||
+	run_install_failure "${legacy_cleanup_failure}" ||
 		fail "${legacy_cleanup_failure}: legacy cleanup recovery scenario failed"
+done
+for recovery_failure in finalization readiness timezone setup rollback; do
+	run_install_failure "${recovery_failure}" ||
+		fail "${recovery_failure}: install recovery scenario failed"
 done
 grep -q 'Unable to install the required WAN-mode event scripts' "${TMP_ROOT}/migration" ||
 	fail 'LAN-to-WAN migration does not abort when WAN event-script synchronization fails'

--- a/tests/installer-install-mode-detection.sh
+++ b/tests/installer-install-mode-detection.sh
@@ -201,10 +201,10 @@ grep -Fq 'if ! finalize_pending_mode_migration; then' "${TMP_ROOT}/install-path"
 	fail 'install orchestration must propagate mode migration finalization failures'
 awk '
 	/if ! finalize_pending_mode_migration; then/ { failure = 1; next }
-	failure && /adguard_restart_after_install_abort "\$\{RESTART_AFTER_ABORT\}"/ { restarted = 1; next }
-	failure && /end_op_message 1 "\$1"/ { exit(restarted ? 0 : 1) }
-	END { if (!failure || !restarted) exit 1 }
-' "${TMP_ROOT}/install-path" || fail 'finalization failure does not restart the previous installation'
+	failure && /adguard_recover_after_event_hook_abort "\$\{RESTART_AFTER_ABORT\}" 1/ { recovered = 1; next }
+	failure && /end_op_message 1 "\$1"/ { exit(recovered ? 0 : 1) }
+	END { if (!failure || !recovered) exit 1 }
+' "${TMP_ROOT}/install-path" || fail 'finalization failure does not recover the previous installation'
 grep -Fq 'return "${MIGRATE_STATUS}"' "${TMP_ROOT}/install-path" ||
 	fail 'install orchestration does not preserve migration rollback failure status'
 awk '
@@ -220,20 +220,19 @@ awk '
 	END { exit(readiness && finalize > readiness ? 0 : 1) }
 ' "${TMP_ROOT}/install-path" || fail 'mode migration is finalized before post-install readiness succeeds'
 awk '
-	/if ! agh_complete_startup; then/ { readiness = 1; next }
-	readiness && /if ! rollback_pending_mode_migration; then/ { rollback = 1; next }
-	rollback && /agh_stop/ { stopped = NR; next }
-	rollback && /adguard_restart_after_install_abort "\$\{RESTART_AFTER_ABORT\}"/ {
+	/if \[ "\$\{2:-0\}" = "1" \]; then/ { readiness = 1; next }
+	readiness && /agh_stop/ { stopped = NR; next }
+	readiness && /adguard_restart_after_install_abort "\$1"/ {
 		restarted = NR
 		exit(stopped && stopped < restarted ? 0 : 1)
 	}
 	END { if (!stopped || !restarted) exit 1 }
-' "${TMP_ROOT}/install-path" || fail 'readiness rollback does not stop the migrated process before restoring the previous service state'
+' "${TMP_ROOT}/event-hook-recovery" || fail 'readiness rollback does not stop the migrated process before restoring the previous service state'
 awk '
 	/if ! set_timezone; then/ { failure = "timezone" }
 	/if ! setup_AdGuardHome "" "\$\{1:-install\}"; then/ { failure = "setup" }
 	/if ! agh_complete_startup; then/ { failure = "readiness" }
-	failure && /rollback_pending_mode_migration/ { rollback[failure] = 1 }
+	failure && /adguard_recover_after_event_hook_abort/ { rollback[failure] = 1 }
 	failure && /end_op_message 1/ {
 		if (!rollback[failure]) exit 1
 		failure = ""
@@ -241,11 +240,12 @@ awk '
 	END { exit(rollback["timezone"] && rollback["setup"] && rollback["readiness"] ? 0 : 1) }
 ' "${TMP_ROOT}/install-path" || fail 'post-migration failure paths can re-enter the menu before rollback'
 awk '
-	/adguard_migrate_detected_install_mode/ { migration = 1; next }
-	migration && /MIGRATE_STATUS=\$\?/ { status = 1; next }
-	status && /\[ "\$\{MIGRATE_STATUS\}" -eq 2 \] \|\| adguard_restart_after_install_abort/ { guarded = 1; exit }
-	END { exit(guarded ? 0 : 1) }
-' "${TMP_ROOT}/install-path" || fail 'migration rollback failure does not block the previous installation restart'
+	/if rollback_pending_mode_migration; then/ { rollback = 1; next }
+	rollback && /else/ { failure = 1; next }
+	failure && /MODE_ROLLBACK_STATUS=1/ { recorded = 1; next }
+	recorded && /adguard_restart_after_install_abort "\$1"/ { restarted = 1; exit }
+	END { exit(restarted ? 0 : 1) }
+' "${TMP_ROOT}/event-hook-recovery" || fail 'migration rollback failure blocks the previous installation restart'
 # run_legacy_cleanup_failure executes one injected legacy-cleanup failure and
 # run_legacy_cleanup_failure verifies aggregate rollback, mode rollback, service and monitor recovery, and failure status for legacy cleanup errors.
 run_legacy_cleanup_failure() (
@@ -336,6 +336,8 @@ EOF
 	all_event_scripts_transaction_detach_after_mode_rollback() { :; }
 	# all_event_scripts_transaction_rollback records an event-script transaction rollback.
 	all_event_scripts_transaction_rollback() { printf '%s\n' 'transaction:rollback' >>"${CALLS_FILE}"; }
+	# nvram_transaction_lock_owned reports that these hook-failure fixtures have no active NVRAM transaction.
+	nvram_transaction_lock_owned() { return 1; }
 	# install_wan_event_scripts reports successful WAN event-script synchronization.
 	install_wan_event_scripts() { return 0; }
 	# rollback_pending_mode_migration records a pending mode migration rollback.

--- a/tests/installer-timezone-failure.sh
+++ b/tests/installer-timezone-failure.sh
@@ -104,8 +104,18 @@ chmod 755 "${TMP_ROOT}/target/AdGuardHome" || fail 'could not create test AdGuar
 	write_conf() { :; }
 	# nvram does nothing and returns success.
 	nvram() { :; }
-	# nvram_transaction_lock_owned reports that this fixture has no active NVRAM transaction.
-	nvram_transaction_lock_owned() { return 1; }
+	# nvram_transaction_lock_owned reports ownership of the fixture's active NVRAM transaction.
+	nvram_transaction_lock_owned() { return 0; }
+	# nvram_transaction_setup_committed reports that the fixture's NVRAM transaction is uncommitted.
+	nvram_transaction_setup_committed() { return 1; }
+	# setup_restore_nvram_journal records restoration of the setup-file NVRAM journal.
+	setup_restore_nvram_journal() { printf '%s\n' 'nvram:journal' >>"${CALLS_FILE}"; }
+	# installer_lan_domain_restore records restoration of the LAN-domain transaction.
+	installer_lan_domain_restore() { printf '%s\n' 'nvram:lan-domain' >>"${CALLS_FILE}"; }
+	# restore_dns_filter_settings records restoration of DNSFilter settings.
+	restore_dns_filter_settings() { printf '%s\n' 'nvram:dns-filter' >>"${CALLS_FILE}"; }
+	# all_event_scripts_transaction_rollback records the aggregate event-script rollback.
+	all_event_scripts_transaction_rollback() { printf '%s\n' 'event-hooks:rollback' >>"${CALLS_FILE}"; }
 	# grep always returns failure.
 	grep() { return 1; }
 	# tar is a no-op stub that suppresses archive command execution.
@@ -149,7 +159,7 @@ chmod 755 "${TMP_ROOT}/target/AdGuardHome" || fail 'could not create test AdGuar
 	fi
 ) || fail 'timezone failure regression subprocess failed'
 
-EXPECTED="$(printf '%s\n' 'timezone' 'restart' 'end:1 install')"
+EXPECTED="$(printf '%s\n' 'timezone' 'event-hooks:rollback' 'nvram:journal' 'nvram:lan-domain' 'nvram:dns-filter' 'restart' 'end:1 install')"
 ACTUAL="$(cat "${CALLS_FILE}")"
 [ "${ACTUAL}" = "${EXPECTED}" ] || fail "installer continued after timezone failure: ${ACTUAL}"
 

--- a/tests/installer-timezone-failure.sh
+++ b/tests/installer-timezone-failure.sh
@@ -24,6 +24,8 @@ trap 'cleanup; exit 1' HUP INT TERM
 mkdir -p "${TMP_ROOT}/base" "${TMP_ROOT}/target" "${TMP_ROOT}/addon" || fail 'could not create test directories'
 sed -n '/^adguard_restart_after_install_abort() {$/,/^}/p' "${SCRIPT_PATH}" >"${FUNCTIONS_FILE}" ||
 	fail 'could not extract restart helper'
+sed -n '/^adguard_recover_after_event_hook_abort() {$/,/^}/p' "${SCRIPT_PATH}" >>"${FUNCTIONS_FILE}" ||
+	fail 'could not extract event-hook recovery helper'
 sed -n '/^adguard_migrate_detected_install_mode() {$/,/^}/p' "${SCRIPT_PATH}" >>"${FUNCTIONS_FILE}" ||
 	fail 'could not extract install-mode migration helper'
 sed -n '/^adguard_install_mode_confirmed() {$/,/^}/p' "${SCRIPT_PATH}" >>"${FUNCTIONS_FILE}" ||
@@ -102,6 +104,8 @@ chmod 755 "${TMP_ROOT}/target/AdGuardHome" || fail 'could not create test AdGuar
 	write_conf() { :; }
 	# nvram does nothing and returns success.
 	nvram() { :; }
+	# nvram_transaction_lock_owned reports that this fixture has no active NVRAM transaction.
+	nvram_transaction_lock_owned() { return 1; }
 	# grep always returns failure.
 	grep() { return 1; }
 	# tar is a no-op stub that suppresses archive command execution.
@@ -145,7 +149,7 @@ chmod 755 "${TMP_ROOT}/target/AdGuardHome" || fail 'could not create test AdGuar
 	fi
 ) || fail 'timezone failure regression subprocess failed'
 
-EXPECTED="$(printf '%s\n' 'timezone' 'rollback' 'restart' 'end:1 install')"
+EXPECTED="$(printf '%s\n' 'timezone' 'restart' 'end:1 install')"
 ACTUAL="$(cat "${CALLS_FILE}")"
 [ "${ACTUAL}" = "${EXPECTED}" ] || fail "installer continued after timezone failure: ${ACTUAL}"
 


### PR DESCRIPTION
### Motivation

- Tests `tests/installer-timezone-failure.sh` and `tests/installer-install-mode-detection.sh` were failing because the centralized recovery helper `adguard_recover_after_event_hook_abort` was not being extracted into the test fixture and finalization failures were not validated against the central recovery path. 
- The intent is to ensure the test fixtures exercise the real recovery orchestration (NVRAM rollback, event-hook recovery, and service restart) so finalization and timezone failure regressions are detected and validated.

### Description

- Update `tests/installer-timezone-failure.sh` to also extract `adguard_recover_after_event_hook_abort` into the generated functions fixture and to provide a `nvram_transaction_lock_owned()` stub used by the recovery helper. 
- Adjust the expected call sequence in `tests/installer-timezone-failure.sh` to match the centralized recovery logic (service restart via the recovery helper). 
- Update `tests/installer-install-mode-detection.sh` assertions to check for the centralized recovery behavior by matching `adguard_recover_after_event_hook_abort` invocations and by routing certain readiness/rollback checks to the extracted `event-hook-recovery` fixture. 
- Add `nvram_transaction_lock_owned()` stub to the hook-failure fixtures in `tests/installer-install-mode-detection.sh` so event-hook recovery paths have the expected NVRAM-lock semantics in tests.

### Testing

- Ran syntax checks: `sh -n tests/installer-timezone-failure.sh` and `sh -n tests/installer-install-mode-detection.sh` (both succeeded). 
- Ran the failing unit tests directly: `sh tests/installer-timezone-failure.sh installer` and `sh tests/installer-install-mode-detection.sh installer`; both tests now pass. 
- Executed the repository-wide validation script `tools/code-quality.sh` under the environment timeout; the modified regressions (timezone and install-mode detection) passed and the bulk of the code-quality checks completed successfully in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a96daa034308329bf0fdf2e8cc13a96)