### PR TITLE
Harden OSV differential checkout and strengthen related tests

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -41,7 +41,7 @@ jobs:
             git fetch --no-tags origin "${base_revision}" || true
           fi
           if git rev-parse --verify "${base_revision}^{commit}" >/dev/null 2>&1; then
-            git checkout --detach "${base_revision}"
+            git checkout --detach "${base_revision}" || exit 1
             printf '%s\n' 'available=true' >> "${GITHUB_OUTPUT}"
           else
             printf '%s\n' '{}' >old-results.json

--- a/tests/adguardhome-runtime-mode-helpers.sh
+++ b/tests/adguardhome-runtime-mode-helpers.sh
@@ -57,8 +57,8 @@ pidof() {
 # iptables prints the configured simulated WAN NAT rule.
 iptables() {
 	printf '%s\n' "$*" >"${TEST_ROOT}/iptables-query"
-	[ "${IPTABLES_FAIL:-0}" -eq 0 ] || return 1
 	printf '%s\n' "${WAN_NAT_RULE:-}"
+	[ "${IPTABLES_FAIL:-0}" -eq 0 ] || return 1
 }
 
 # assert_iptables_query verifies the production helper used the expected WAN NAT query.
@@ -128,10 +128,11 @@ WAN_NAT_RULE='-A POSTROUTING -o eth3 -j SNAT --to-source 192.0.2.1'
 adguard_wan_iptables_state_active || fail 'wan1 gateway interface did not qualify as WAN NAT state'
 WAN_NAT_RULE='-A POSTROUTING -o ppp1 -j MASQUERADE'
 adguard_wan_iptables_state_active || fail 'wan1 PPPoE interface did not qualify as WAN NAT state'
-WAN_NAT_RULE=''
+WAN_NAT_RULE='-A POSTROUTING -o eth0 -j MASQUERADE'
 IPTABLES_FAIL=1
 ! adguard_ipset_allowed || fail 'LAN install mode allowed IPSET when iptables was unavailable'
 IPTABLES_FAIL=0
+WAN_NAT_RULE=''
 
 CONFIG_INSTALL_MODE='ap'
 ! adguard_ipset_allowed || fail 'AP install mode without WAN NAT state should not allow IPSET'

--- a/tests/coderabbit-and-workflow-config-checks.sh
+++ b/tests/coderabbit-and-workflow-config-checks.sh
@@ -360,6 +360,8 @@ grep -Fq "if: github.event_name != 'pull_request' || github.event.pull_request.h
 	fail '.github/workflows/osv-scanner.yml: full vulnerability scan must exclude fork pull requests'
 grep -Fq "git rev-parse --verify \"\${base_revision}^{commit}\"" '.github/workflows/osv-scanner.yml' ||
 	fail '.github/workflows/osv-scanner.yml: differential scan must verify that its predecessor is reachable'
+grep -Fq 'git checkout --detach "${base_revision}" || exit 1' '.github/workflows/osv-scanner.yml' ||
+	fail '.github/workflows/osv-scanner.yml: differential scan must stop when predecessor checkout fails'
 osv_differential_uploads_are_guarded '.github/workflows/osv-scanner.yml' ||
 	fail '.github/workflows/osv-scanner.yml: both differential SARIF uploads must require an available report'
 for mutation in artifact-missing artifact-or artifact-subsequent code-scanning-missing code-scanning-or code-scanning-subsequent; do

--- a/tests/installer-event-script-transactions.sh
+++ b/tests/installer-event-script-transactions.sh
@@ -22,8 +22,16 @@ trap 'cleanup; exit 1' HUP INT TERM
 
 [ -f "${SCRIPT_PATH}" ] || fail "installer script not found: ${SCRIPT_PATH}"
 mkdir -p "${TMP_DIR}/jffs/scripts" "${TMP_DIR}/base" || fail 'could not create transaction fixture'
-sed -n '/^event_scripts_snapshot() {$/,$ { /^remove_firewall_event_scripts() {$/q; p; }' "${SCRIPT_PATH}" >"${TMP_DIR}/helpers.part" ||
+grep -q '^remove_firewall_event_scripts() {$' "${SCRIPT_PATH}" || fail 'firewall transaction helper extraction boundary is missing'
+sed -n '/^event_scripts_snapshot() {$/,/^remove_firewall_event_scripts() {$/p' "${SCRIPT_PATH}" >"${TMP_DIR}/helpers.range" ||
 	fail 'could not extract event-script transaction helpers'
+tail -n 1 "${TMP_DIR}/helpers.range" | grep -q '^remove_firewall_event_scripts() {$' ||
+	fail 'firewall transaction helper extraction did not end at its boundary'
+sed '$d' "${TMP_DIR}/helpers.range" >"${TMP_DIR}/helpers.part" ||
+	fail 'could not remove the firewall transaction helper extraction boundary'
+if grep -q "^trap 'on_installer_exit' EXIT$" "${TMP_DIR}/helpers.part"; then
+	fail 'event-script transaction helper extraction included installer top-level flow'
+fi
 sed -n '/^remove_firewall_event_scripts() {$/,/^}$/p' "${SCRIPT_PATH}" >>"${TMP_DIR}/helpers.part" ||
 	fail 'could not complete firewall transaction helper extraction'
 sed -n '/^install_wan_event_scripts() {$/,/^}$/p' "${SCRIPT_PATH}" >>"${TMP_DIR}/helpers.part" ||


### PR DESCRIPTION
### Motivation

- Prevent the differential OSV scan from proceeding when the verified base revision cannot actually be checked out so `available=true` cannot be written for a failed checkout. 
- Make the runtime IPSET regression test robust by isolating the `iptables` command-failure guard from the test data it inspects. 
- Protect the installer helper-extraction test from accidental sourcing of installer top-level flow when the expected extraction boundary is missing or moved.

### Description

- In `.github/workflows/osv-scanner.yml`, fail the step if `git checkout --detach "${base_revision}"` fails by adding `|| exit 1` so `available=true` is written only after a successful checkout. 
- In `tests/coderabbit-and-workflow-config-checks.sh`, add an assertion that the workflow contains the guarded checkout (`git checkout --detach "${base_revision}" || exit 1`).
- In `tests/adguardhome-runtime-mode-helpers.sh`, adjust the `iptables()` test stub to emit the configured `WAN_NAT_RULE` before returning the configured failure status and ensure the `WAN_NAT_RULE` used for the `IPTABLES_FAIL=1` assertion is present while `iptables` reports failure. 
- In `tests/installer-event-script-transactions.sh`, validate the helper extraction boundary by checking for `remove_firewall_event_scripts() {` before extraction, confirm the extraction range ends at that boundary, remove the boundary line from the extracted part, and fail early if the extracted helper fragment contains installer top-level flow such as `trap 'on_installer_exit' EXIT`.

### Testing

- Ran syntax checks: `sh -n tests/adguardhome-runtime-mode-helpers.sh`, `sh -n tests/installer-event-script-transactions.sh`, and `sh -n tests/coderabbit-and-workflow-config-checks.sh`, all succeeded. 
- Ran the runtime and transaction tests: `sh tests/adguardhome-runtime-mode-helpers.sh` and `sh tests/installer-event-script-transactions.sh` both passed under normal fixtures. 
- Verified regression/mutation behavior: a mutation that removed the production `|| return 1` guard caused `tests/adguardhome-runtime-mode-helpers.sh` to fail with `FAIL: LAN install mode allowed IPSET when iptables was unavailable`, and renaming `remove_firewall_event_scripts()` caused `tests/installer-event-script-transactions.sh` to exit with `FAIL: firewall transaction helper extraction boundary is missing`, both of which are the expected outcomes. 
- Validated workflow YAML parsing with `ruby -e "require 'psych'; Psych.parse_file('.github/workflows/osv-scanner.yml')"` and ran `git diff --check`, both passing with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9c5c6016208329b4c18b0f2b84850e)