### PR TITLE
ci: add top-level concurrency to Semgrep workflow to cancel superseded runs

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -8,6 +8,10 @@ on:
     - cron: '17 6 * * 1'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
### Motivation

- Prevent redundant GitHub Actions runs when a branch update triggers both `push` and `pull_request` workflows by adding workflow-level concurrency that cancels in-progress superseded runs.

### Description

- Inserted a top-level `concurrency:` block in `.github/workflows/semgrep.yml` with `group: ${{ github.workflow }}-${{ github.ref }}` and `cancel-in-progress: true`, leaving all existing triggers, permissions, jobs, and steps unchanged.

### Testing

- Validated the change with `git diff --check` and a YAML parse/structure check using Ruby which confirmed `pull_request`, `merge_group`, `push`, `schedule`, and `workflow_dispatch` remain present and `concurrency` is top-level and correct; `actionlint` was not available in the environment and the Python YAML check could not run because the `yaml` module (`PyYAML`) is unavailable, but equivalent validation with Ruby succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9d8edf97f08329a2df16952c14943c)